### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,110 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+# Cancel in-progress runs when a PR is pushed again. Pushes to master are
+# left alone so every master commit gets its own confirmed-green run.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  php-quality:
+    name: PHP format + PHPStan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+      - name: Cache Composer
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer-${{ runner.os }}-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-${{ runner.os }}-
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+      - name: Run format check + PHPStan
+        run: composer check
+
+  composer-audit:
+    name: Composer audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+      - name: Cache Composer
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer-${{ runner.os }}-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-${{ runner.os }}-
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+      - name: Audit dependencies
+        run: composer audit
+
+  js-lint:
+    name: ESLint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install ESLint
+        # Versions pinned to match docs/dev/Dockerfile.dev. Keep in sync when
+        # bumping either side.
+        run: |
+          npm install -g \
+            eslint@9.16.0 \
+            @eslint/js@9.16.0 \
+            eslint-plugin-html@8.1.2 \
+            globals@15.13.0
+          echo "NODE_PATH=$(npm root -g)" >> "$GITHUB_ENV"
+      - name: Lint JavaScript
+        run: eslint script
+
+  repo-checkers:
+    name: In-repo checker scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+      - name: Database access boundary check
+        run: php docs/ai/review-database-access/scripts/check-db-access.php --all
+      - name: Playoff layout templates check
+        run: php docs/ai/review-playoff-layouts/scripts/check-playoff-layouts.php
+
+  release-package-smoke:
+    name: Release package build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The release script uses `git describe` and `git ls-files`; full
+          # history avoids shallow-clone surprises.
+          fetch-depth: 0
+      - name: Build release package
+        run: bash docs/release/build-release.sh
+      - name: Verify archive contents
+        run: |
+          set -euo pipefail
+          archive="$(ls dist/ultiorganizer-install-*.zip | head -n 1)"
+          test -n "$archive"
+          unzip -l "$archive" | grep -q 'index\.php$'
+          echo "Built: $archive"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,18 @@ Prefer reusing shared helpers in `lib/` before adding new utility code or direct
 - Start the workspace with `docker compose -f docs/dev/compose.yaml --profile devtools up --build dev` and run commands with `docker compose -f docs/dev/compose.yaml exec -T dev ...`. If the `dev` service is unavailable but `app` is running, use `docker compose -f docs/dev/compose.yaml exec -T app ...` for equivalent PHP-based checks.
 - Verify changes by running the app and exercising the relevant page flow.
 
+## CI
+
+GitHub Actions runs the same checks automatically on every push to `master` and on every pull request. The workflow is at [`.github/workflows/ci.yml`](.github/workflows/ci.yml) and has five jobs:
+
+- `php-quality` — `composer check` (PHP-CS-Fixer + PHPStan) on PHP 8.3.
+- `composer-audit` — `composer audit` against `composer.lock`; fails on any reported security advisory.
+- `js-lint` — `eslint script` against the same ESLint 9 config used locally (`eslint.config.js`).
+- `repo-checkers` — DB access boundary check and playoff layout templates check.
+- `release-package-smoke` — runs `docs/release/build-release.sh` and asserts the archive contains `index.php`.
+
+Pre-commit hooks remain the fast local gate; CI is the source of truth for what is allowed to merge. The test harness in the sibling `ultiorganizer-tests` repo is not wired into CI yet; run it locally per its README.
+
 ## Topic docs
 
 - `docs/README.md`: index of project documentation under `docs/`.

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -75,6 +75,8 @@ docker compose -f docs/dev/compose.yaml exec -T dev composer install
 
 ## Pre-commit hook
 
+The same checks run automatically in GitHub Actions on every push and pull request (see [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)). The pre-commit hook is the fast local gate; CI is the source of truth for what is allowed to merge.
+
 The repository ships a pre-commit hook at [`.githooks/pre-commit`](../.githooks/pre-commit) that runs PHP-CS-Fixer (with auto-fix and re-stage) and PHPStan against staged PHP files. Enable it once per clone:
 
 ```sh

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -41,6 +41,13 @@ parameters:
             paths:
                 - sql/upgrade_db.php
                 - user/playerprofile.php
+        -
+            # conf/config.inc.php is generated at install time and intentionally gitignored;
+            # both include sites are guarded by is_readable/is_file checks.
+            message: '#^Path in include_once\(\) "conf/config\.inc\.php" is not a file or it does not exist\.$#'
+            paths:
+                - index.php
+                - install.php
     parallel:
         maximumNumberOfProcesses: 4
     treatPhpDocTypesAsCertain: false


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` running on every push to `master` and every pull request, with five jobs: `composer check` (PHP-CS-Fixer + PHPStan), `composer audit`, ESLint, the in-repo DB-access and playoff-layout checker scripts, and a release-package build smoke.
- Uses the `pull_request` event (not `pull_request_target`) so fork PRs from external contributors run with their own code and no secrets exposure.
- Documents the workflow in `AGENTS.md` (new `## CI` section) and cross-references it from `docs/code-style.md`.

Phase 1 of two; the `ultiorganizer-tests` harness is intentionally not wired in here. That requires the separate decision to make the tests repo public and a cross-repo checkout step, planned as a follow-up.

ESLint package versions in the workflow are pinned to match `docs/dev/Dockerfile.dev`; keep them in sync when bumping either side.

## Test plan

- [x] All five jobs go green on this PR.
- [ ] Confirm `composer check` covers the same files locally and in CI (no `dist/` drift).
- [ ] Sanity-check a deliberately bad push later (e.g. an indent regression) fails the right job.
- [ ] After green merge, configure required-status-checks on `master` via repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)