### PR TITLE
Add test harness job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,3 +108,38 @@ jobs:
           test -n "$archive"
           unzip -l "$archive" | grep -q 'index\.php$'
           echo "Built: $archive"
+
+  harness:
+    name: Test harness (full matrix)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout SUT (this PR)
+        uses: actions/checkout@v4
+        with:
+          path: ultiorganizer
+      - name: Checkout test harness
+        uses: actions/checkout@v4
+        with:
+          repository: ktolonen/ultiorganizer-tests
+          ref: main
+          path: ultiorganizer-tests
+      - name: Run doctor
+        working-directory: ultiorganizer-tests
+        run: ./doctor
+      - name: Run full matrix against this PR
+        working-directory: ultiorganizer-tests
+        # The harness defaults --sut-path to ../ultiorganizer, which the
+        # sibling checkout layout above satisfies. Empty --pr-* values on
+        # push events are treated as a local checkout context.
+        run: |
+          ./test:matrix \
+            --pr-number "${{ github.event.pull_request.number }}" \
+            --pr-head-ref "${{ github.head_ref }}" \
+            --pr-base-ref "${{ github.base_ref }}"
+      - name: Upload reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: harness-reports
+          path: ultiorganizer-tests/reports/
+          retention-days: 14

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,15 +68,16 @@ Prefer reusing shared helpers in `lib/` before adding new utility code or direct
 
 ## CI
 
-GitHub Actions runs the same checks automatically on every push to `master` and on every pull request. The workflow is at [`.github/workflows/ci.yml`](.github/workflows/ci.yml) and has five jobs:
+GitHub Actions runs the same checks automatically on every push to `master` and on every pull request. The workflow is at [`.github/workflows/ci.yml`](.github/workflows/ci.yml) and has six jobs:
 
 - `php-quality` — `composer check` (PHP-CS-Fixer + PHPStan) on PHP 8.3.
 - `composer-audit` — `composer audit` against `composer.lock`; fails on any reported security advisory.
 - `js-lint` — `eslint script` against the same ESLint 9 config used locally (`eslint.config.js`).
 - `repo-checkers` — DB access boundary check and playoff layout templates check.
 - `release-package-smoke` — runs `docs/release/build-release.sh` and asserts the archive contains `index.php`.
+- `harness` — checks out the sibling `ktolonen/ultiorganizer-tests` repository and runs its full test matrix (lint, unit, integration, export, api, smoke, crawl) against the pull request's code.
 
-Pre-commit hooks remain the fast local gate; CI is the source of truth for what is allowed to merge. The test harness in the sibling `ultiorganizer-tests` repo is not wired into CI yet; run it locally per its README.
+Pre-commit hooks remain the fast local gate; CI is the source of truth for what is allowed to merge. The `harness` job is the production test suite — it lives in a separate public repository so it can be developed and versioned independently; see that repository's README for the suite definitions and how to run it locally.
 
 ## Topic docs
 


### PR DESCRIPTION
## Summary

- Adds a `harness` job to `.github/workflows/ci.yml` that checks out the public `ktolonen/ultiorganizer-tests` repository as a sibling and runs its full test matrix (lint, unit, integration, export, api, smoke, crawl) against this PR's code.
- PR metadata is passed through the harness `--pr-*` flags for report context labeling.
- Because the tests repository is public, `actions/checkout` fetches it without a token, so the job also runs on pull requests from forks.
- Updates the `## CI` section of `AGENTS.md` (5 → 6 jobs).

Phase 2 of the CI work; Phase 1 (#44) added the self-contained checks. The harness itself gains its own CI in ktolonen/ultiorganizer-tests#1.

## Test plan

- [ ] The `harness` job runs the full matrix and goes green on this PR.
- [ ] The five existing jobs still pass.
- [ ] `harness-reports` artifact is uploaded if the matrix fails.
- [ ] After green merge, add the `harness` job to required-status-checks on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)