### PR TITLE
Surface harness reports in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,8 +136,29 @@ jobs:
             --pr-number "${{ github.event.pull_request.number }}" \
             --pr-head-ref "${{ github.head_ref }}" \
             --pr-base-ref "${{ github.base_ref }}"
-      - name: Upload reports on failure
-        if: failure()
+      - name: Publish job summary
+        if: always()
+        working-directory: ultiorganizer-tests
+        run: |
+          {
+            echo "# Test harness — full matrix"
+            echo
+            found=0
+            while IFS= read -r f; do
+              found=1
+              cat "$f"
+              echo
+            done < <(find reports -path '*/summary/summary.md' | sort)
+            if [ "$found" -eq 0 ]; then
+              echo "_No case summaries were produced; see the run log above._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Build HTML report
+        if: always()
+        working-directory: ultiorganizer-tests
+        run: ./report:html
+      - name: Upload reports
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: harness-reports

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ GitHub Actions runs the same checks automatically on every push to `master` and 
 - `js-lint` — `eslint script` against the same ESLint 9 config used locally (`eslint.config.js`).
 - `repo-checkers` — DB access boundary check and playoff layout templates check.
 - `release-package-smoke` — runs `docs/release/build-release.sh` and asserts the archive contains `index.php`.
-- `harness` — checks out the sibling `ktolonen/ultiorganizer-tests` repository and runs its full test matrix (lint, unit, integration, export, api, smoke, crawl) against the pull request's code.
+- `harness` — checks out the sibling `ktolonen/ultiorganizer-tests` repository and runs its full test matrix (lint, unit, integration, export, api, smoke, crawl) against the pull request's code. Per-case results are written to the run's job summary, and the full report tree (including the `report:html` browser index) is uploaded as the `harness-reports` artifact.
 
 Pre-commit hooks remain the fast local gate; CI is the source of truth for what is allowed to merge. The `harness` job is the production test suite — it lives in a separate public repository so it can be developed and versioned independently; see that repository's README for the suite definitions and how to run it locally.
 


### PR DESCRIPTION
## Summary

Adds result-visibility steps to the `harness` job, mirroring ktolonen/ultiorganizer-tests#2. All run on every outcome (`if: always()`):

- **Publish job summary** — concatenates each case's `summary.md` into `$GITHUB_STEP_SUMMARY`, so per-case pass/fail shows on the PR's run page with no download.
- **Build HTML report + upload** — runs `./report:html`, then uploads the whole `reports/` tree as the `harness-reports` artifact, replacing the previous failure-only upload.

`AGENTS.md` CI section updated.

## Test plan

- [ ] `harness` job goes green; job summary shows the per-case breakdown.
- [ ] `harness-reports` artifact is present on a passing run and contains `index.html`.
- [ ] The five other CI jobs still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)