### PR TITLE
[codex] Reduce repeated playoff placement queries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,8 +136,29 @@ jobs:
             --pr-number "${{ github.event.pull_request.number }}" \
             --pr-head-ref "${{ github.head_ref }}" \
             --pr-base-ref "${{ github.base_ref }}"
-      - name: Upload reports on failure
-        if: failure()
+      - name: Publish job summary
+        if: always()
+        working-directory: ultiorganizer-tests
+        run: |
+          {
+            echo "# Test harness — full matrix"
+            echo
+            found=0
+            while IFS= read -r f; do
+              found=1
+              cat "$f"
+              echo
+            done < <(find reports -path '*/summary/summary.md' | sort)
+            if [ "$found" -eq 0 ]; then
+              echo "_No case summaries were produced; see the run log above._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Build HTML report
+        if: always()
+        working-directory: ultiorganizer-tests
+        run: ./report:html
+      - name: Upload reports
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: harness-reports

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ GitHub Actions runs the same checks automatically on every push to `master` and 
 - `js-lint` — `eslint script` against the same ESLint 9 config used locally (`eslint.config.js`).
 - `repo-checkers` — DB access boundary check and playoff layout templates check.
 - `release-package-smoke` — runs `docs/release/build-release.sh` and asserts the archive contains `index.php`.
-- `harness` — checks out the sibling `ktolonen/ultiorganizer-tests` repository and runs its full test matrix (lint, unit, integration, export, api, smoke, crawl) against the pull request's code.
+- `harness` — checks out the sibling `ktolonen/ultiorganizer-tests` repository and runs its full test matrix (lint, unit, integration, export, api, smoke, crawl) against the pull request's code. Per-case results are written to the run's job summary, and the full report tree (including the `report:html` browser index) is uploaded as the `harness-reports` artifact.
 
 Pre-commit hooks remain the fast local gate; CI is the source of truth for what is allowed to merge. The `harness` job is the production test suite — it lives in a separate public repository so it can be developed and versioned independently; see that repository's README for the suite definitions and how to run it locally.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ Pre-commit hooks remain the fast local gate; CI is the source of truth for what 
 - `docs/codebase-notes.md`: third-party components, PDF generation, plugins, and customization notes.
 - `docs/lib-index.md`: file-by-file map of shared helpers and third-party libraries under `lib/`.
 - `docs/routing.md`: request entry points and view resolution.
+- `docs/runtime-cache.md`: request-local helper caching guidance and database-log recapture commands.
 - `docs/deployment.md`: production release package and installation guidance.
 - `docs/local-development.md`: local Docker-based setup.
 - `docs/dev/`: Docker Compose assets and image definitions used by the local development guide.
@@ -123,7 +124,6 @@ Pre-commit hooks remain the fast local gate; CI is the source of truth for what 
 
 ### AI review assets
 
-- `docs/ai/runtime-cache.md`: guidance for request-local helper caching and live-scoring cache boundaries.
 - `docs/ai/review-user-language/SKILL.md`: read-only skill for reviewing user-facing spelling, grammar, and terminology consistency.
 - `docs/ai/fix-user-language/SKILL.md`: fix skill for page-level or term-level user-facing wording and gettext updates.
 - `docs/ai/review-database-access/SKILL.md`: read-only skill for reviewing database access boundary violations and legacy cursor-style DB helper usage.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,7 @@ Pre-commit hooks remain the fast local gate; CI is the source of truth for what 
 
 ### AI review assets
 
+- `docs/ai/runtime-cache.md`: guidance for request-local helper caching and live-scoring cache boundaries.
 - `docs/ai/review-user-language/SKILL.md`: read-only skill for reviewing user-facing spelling, grammar, and terminology consistency.
 - `docs/ai/fix-user-language/SKILL.md`: fix skill for page-level or term-level user-facing wording and gettext updates.
 - `docs/ai/review-database-access/SKILL.md`: read-only skill for reviewing database access boundary violations and legacy cursor-style DB helper usage.

--- a/admin/poolmoves.php
+++ b/admin/poolmoves.php
@@ -200,8 +200,9 @@ function PoolHasMovesFromAllPositions($poolId)
         return false;
     }
 
+    $movedPlacings = PoolMovedPlacings($poolId);
     for ($i = 1; $i <= $total_teams; $i++) {
-        if (!PoolMoveExist($poolId, $i)) {
+        if (!isset($movedPlacings[$i])) {
             return false;
         }
     }

--- a/admin/seasonpools.php
+++ b/admin/seasonpools.php
@@ -147,22 +147,21 @@ foreach ($pools as $pool) {
         $placementto = 0;
         foreach ($ppools as $ppool) {
             $teams = PoolTeams($ppool['pool_id']);
+            $movedPlacings = PoolMovedPlacings($ppool['pool_id']);
             if (count($teams) == 0) {
                 $teams = PoolSchedulingTeams($ppool['pool_id']);
             }
             if ($pool['pool_id'] == $ppool['pool_id']) {
 
                 for ($i = 1; $i <= count($teams); $i++) {
-                    $moved = PoolMoveExist($ppool['pool_id'], $i);
-                    if (!$moved) {
+                    if (!isset($movedPlacings[$i])) {
                         $placementto++;
                     }
                 }
                 break;
             }
             for ($i = 1; $i <= count($teams); $i++) {
-                $moved = PoolMoveExist($ppool['pool_id'], $i);
-                if (!$moved) {
+                if (!isset($movedPlacings[$i])) {
                     $placementfrom++;
                     $placementto++;
                 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ This directory collects general project documentation.
 
 ### AI review assets
 
+- `ai/runtime-cache.md`: guidance for request-local helper caching and live-scoring cache boundaries.
 - `ai/review-user-language/SKILL.md`: read-only review skill for project spelling, grammar, and terminology consistency in user-facing content.
 - `ai/fix-user-language/SKILL.md`: fix skill for user-facing wording, terminology normalization, and gettext-backed copy updates.
 - `ai/review-database-access/SKILL.md`: read-only review skill for database access boundaries, page-layer DB usage, and legacy cursor-style APIs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ This directory collects general project documentation.
 - `codebase-notes.md`: third-party components, PDF generation, plugins, and customization notes.
 - `lib-index.md`: file-by-file map of shared helpers and third-party libraries under `lib/`.
 - `routing.md`: request entry points and view resolution.
+- `runtime-cache.md`: request-local helper caching guidance and database-log recapture commands.
 - `deployment.md`: production release package and installation guidance.
 - `local-development.md`: local Docker-based setup.
 - `dev/`: Docker Compose assets and image definitions used by the local development guide.
@@ -44,7 +45,6 @@ This directory collects general project documentation.
 
 ### AI review assets
 
-- `ai/runtime-cache.md`: guidance for request-local helper caching and live-scoring cache boundaries.
 - `ai/review-user-language/SKILL.md`: read-only review skill for project spelling, grammar, and terminology consistency in user-facing content.
 - `ai/fix-user-language/SKILL.md`: fix skill for user-facing wording, terminology normalization, and gettext-backed copy updates.
 - `ai/review-database-access/SKILL.md`: read-only review skill for database access boundaries, page-layer DB usage, and legacy cursor-style APIs.

--- a/docs/ai/runtime-cache.md
+++ b/docs/ai/runtime-cache.md
@@ -1,0 +1,88 @@
+# Runtime Cache Guidance
+
+Use `lib/cache.functions.php` for request-local caching of repeated deterministic helper lookups.
+
+This cache is intentionally small in scope:
+
+- It lives only for the current PHP request.
+- It should be used only when the same helper can repeat the same database lookup several times during one request.
+- It should not be used as a cross-request live scoring cache.
+- It should not be used for helpers that only appear frequently because a crawler visited many different pages.
+
+Prefer explicit helper-level use such as season metadata, static spirit-category counts, or stats availability checks. Do not add transparent caching inside the low-level database wrappers unless the invalidation rules are clear for live scoring writes.
+
+When a cached helper reads data that can be changed in the same request, clear the relevant namespace from the mutation helper after the write succeeds.
+
+## Recapture Database Logs
+
+Use the local MariaDB table logs to compare query counts before and after cache changes.
+
+Start a fresh capture:
+
+```sh
+docker compose -f docs/dev/compose.yaml exec -T db sh -lc \
+'mariadb -uroot -p"$MYSQL_ROOT_PASSWORD" -e "
+SET GLOBAL log_output = '\''TABLE'\'';
+SET GLOBAL general_log = OFF;
+SET GLOBAL slow_query_log = OFF;
+TRUNCATE TABLE mysql.general_log;
+TRUNCATE TABLE mysql.slow_log;
+SET GLOBAL long_query_time = 0;
+SET GLOBAL general_log = ON;
+SET GLOBAL slow_query_log = ON;
+"'
+```
+
+Run the same crawl or page flow, then inspect query frequency:
+
+```sh
+docker compose -f docs/dev/compose.yaml exec -T db sh -lc \
+'mariadb -uroot -p"$MYSQL_ROOT_PASSWORD" -e "
+SELECT COUNT(*) AS hits, argument
+FROM mysql.general_log
+WHERE command_type = '\''Query'\''
+GROUP BY argument
+ORDER BY hits DESC
+LIMIT 80;
+"'
+```
+
+Inspect timing:
+
+```sh
+docker compose -f docs/dev/compose.yaml exec -T db sh -lc \
+'mariadb -uroot -p"$MYSQL_ROOT_PASSWORD" -e "
+SELECT
+  COUNT(*) AS hits,
+  SUM(TIME_TO_SEC(query_time)) AS total_sec,
+  AVG(TIME_TO_SEC(query_time)) * 1000 AS avg_ms,
+  MAX(TIME_TO_SEC(query_time)) * 1000 AS max_ms,
+  rows_examined,
+  sql_text
+FROM mysql.slow_log
+WHERE sql_text NOT LIKE '\''%mysql.general_log%'\''
+  AND sql_text NOT LIKE '\''%mysql.slow_log%'\''
+GROUP BY sql_text, rows_examined
+ORDER BY total_sec DESC
+LIMIT 50;
+"'
+```
+
+Turn logging off after the capture:
+
+```sh
+docker compose -f docs/dev/compose.yaml exec -T db sh -lc \
+'mariadb -uroot -p"$MYSQL_ROOT_PASSWORD" -e "
+SET GLOBAL general_log = OFF;
+SET GLOBAL slow_query_log = OFF;
+"'
+```
+
+When comparing captures, watch whether these counts drop:
+
+- `SELECT COUNT(*) FROM uo_spirit_category WHERE mode=... AND index > 0`
+- `SELECT * FROM uo_season WHERE season_id=...`
+- `SELECT season_id ... FROM uo_season WHERE iscurrent=1 ...`
+- `SELECT maintenance_mode FROM uo_season ...`
+- `SELECT 1 FROM uo_season_stats LIMIT 1`
+- `SELECT name FROM uo_team WHERE team_id=''`

--- a/docs/lib-index.md
+++ b/docs/lib-index.md
@@ -7,6 +7,7 @@ Use this index to find existing shared helpers before adding new utility code or
 - `lib/accreditation.functions.php`: player accreditation, license data, acknowledgements, and accreditation logs.
 - `lib/api.functions.php`: API token hashing, lookup, touch, CRUD, and rate limiting.
 - `lib/auth.guard.php`: include-time auth guard that starts the session and redirects anonymous users.
+- `lib/cache.functions.php`: request-local cache helpers for repeated deterministic lookups.
 - `lib/club.functions.php`: club CRUD, club-team links, profiles, images, and external URLs.
 - `lib/comment.functions.php`: game and spirit comment storage, permission checks, metadata, HTML rendering, and logging hooks.
 - `lib/common.functions.php`: shared low-level helpers for dates, locale/time formatting, colors, CSV export, SQL filter/order builders, view resolution, and generic comment helpers.

--- a/docs/runtime-cache.md
+++ b/docs/runtime-cache.md
@@ -5,11 +5,10 @@ Use `lib/cache.functions.php` for request-local caching of repeated deterministi
 This cache is intentionally small in scope:
 
 - It lives only for the current PHP request.
-- It should be used only when the same helper can repeat the same database lookup several times during one request.
+- It should be used only when the same helper can repeat the same database lookup several times during one request (= one page load).
 - It should not be used as a cross-request live scoring cache.
-- It should not be used for helpers that only appear frequently because a crawler visited many different pages.
 
-Prefer explicit helper-level use such as season metadata, static spirit-category counts, or stats availability checks. Do not add transparent caching inside the low-level database wrappers unless the invalidation rules are clear for live scoring writes.
+Example: use runtime caching when one routed page calls `SeasonInfo($seasonId)` early for event metadata and later calls helpers such as `SeasonName($seasonId)`, `Seasontype($seasonId)`, or `IsSeasonInMaintenance($seasonId)` for the same event. The first call can load the row, and later helpers can reuse it during that same page load.
 
 When a cached helper reads data that can be changed in the same request, clear the relevant namespace from the mutation helper after the write succeeds.
 
@@ -77,12 +76,3 @@ SET GLOBAL general_log = OFF;
 SET GLOBAL slow_query_log = OFF;
 "'
 ```
-
-When comparing captures, watch whether these counts drop:
-
-- `SELECT COUNT(*) FROM uo_spirit_category WHERE mode=... AND index > 0`
-- `SELECT * FROM uo_season WHERE season_id=...`
-- `SELECT season_id ... FROM uo_season WHERE iscurrent=1 ...`
-- `SELECT maintenance_mode FROM uo_season ...`
-- `SELECT 1 FROM uo_season_stats LIMIT 1`
-- `SELECT name FROM uo_team WHERE team_id=''`

--- a/lib/cache.functions.php
+++ b/lib/cache.functions.php
@@ -1,0 +1,60 @@
+<?php
+
+require_once __DIR__ . '/include_only.guard.php';
+denyDirectLibAccess(__FILE__);
+
+/**
+ * Build a stable request-local cache key.
+ *
+ * @param string $namespace Logical cache namespace such as "season_info"
+ * @param mixed $key Namespace-specific cache key
+ * @return string
+ */
+function CacheRuntimeKey($namespace, $key)
+{
+    if (is_scalar($key) || $key === null) {
+        $keyText = (string) $key;
+    } else {
+        $keyText = md5(serialize($key));
+    }
+
+    return (string) $namespace . ':' . $keyText;
+}
+
+/**
+ * Return a request-local cached value, computing it when missing.
+ *
+ * This cache lives only for the current PHP request. Use it for repeated,
+ * deterministic helper lookups, not as a cross-request live scoring cache.
+ *
+ * @param string $namespace Logical cache namespace
+ * @param mixed $key Namespace-specific cache key
+ * @param callable $resolver Function that returns the value on cache miss
+ * @return mixed
+ */
+function CacheRemember($namespace, $key, $resolver)
+{
+    $cacheKey = CacheRuntimeKey($namespace, $key);
+    if (array_key_exists($cacheKey, $GLOBALS['runtime_cache'] ?? [])) {
+        return $GLOBALS['runtime_cache'][$cacheKey];
+    }
+
+    $GLOBALS['runtime_cache'][$cacheKey] = $resolver();
+    return $GLOBALS['runtime_cache'][$cacheKey];
+}
+
+/**
+ * Clear all request-local cached values for a namespace.
+ *
+ * @param string $namespace Logical cache namespace
+ * @return void
+ */
+function CacheForgetNamespace($namespace)
+{
+    $prefix = (string) $namespace . ':';
+    foreach (array_keys($GLOBALS['runtime_cache'] ?? []) as $cacheKey) {
+        if (str_starts_with((string) $cacheKey, $prefix)) {
+            unset($GLOBALS['runtime_cache'][$cacheKey]);
+        }
+    }
+}

--- a/lib/pool.functions.php
+++ b/lib/pool.functions.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/include_only.guard.php';
 denyDirectLibAccess(__FILE__);
 
+require_once __DIR__ . '/cache.functions.php';
 require_once __DIR__ . '/season.functions.php';
 require_once __DIR__ . '/team.functions.php';
 require_once __DIR__ . '/swissdraw.functions.php';
@@ -276,17 +277,16 @@ function PoolPlacementString($poolId, $pos, $ordinal = true)
         $placementfrom = 1;
         foreach ($ppools as $ppool) {
             $teams = PoolSchedulingTeams($ppool['pool_id']);
+            $movedPlacings = PoolMovedPlacings($ppool['pool_id']);
             if ($info['pool_id'] != $ppool['pool_id']) {
                 for ($i = 1; $i <= count($teams); $i++) {
-                    $moved = PoolMoveExist($ppool['pool_id'], $i);
-                    if (!$moved) {
+                    if (!isset($movedPlacings[$i])) {
                         $placementfrom++;
                     }
                 }
             } else {
                 for ($i = 1; $i <= count($teams) && $i < $pos; $i++) {
-                    $moved = PoolMoveExist($ppool['pool_id'], $i);
-                    if (!$moved) {
+                    if (!isset($movedPlacings[$i])) {
                         $placementfrom++;
                     }
                 }
@@ -1090,6 +1090,32 @@ function PoolMoveExist($frompool, $fromplacing)
 }
 
 /**
+ * Return moved fromplacing values for a source pool.
+ *
+ * @param int $frompool
+ * @return array<int, bool>
+ */
+function PoolMovedPlacings($frompool)
+{
+    $frompool = (int) $frompool;
+    return CacheRemember('pool_moved_placings', $frompool, function () use ($frompool) {
+        $query = sprintf(
+            "SELECT fromplacing
+            FROM uo_moveteams
+            WHERE frompool=%d",
+            $frompool,
+        );
+
+        $placings = [];
+        foreach (DBQueryToArray($query) as $row) {
+            $placings[(int) $row['fromplacing']] = true;
+        }
+
+        return $placings;
+    });
+}
+
+/**
  * Test if all moves done.
  *
  * @param int $topool
@@ -1467,6 +1493,7 @@ function DeletePool($poolId)
         );
 
         DBQuery($query);
+        CacheForgetNamespace('pool_moved_placings');
     } else {
         die('Insufficient rights to delete pool');
     }
@@ -1926,7 +1953,9 @@ function PoolAddMove($frompool, $topool, $fromplacing, $torank, $pteamname)
             (int) $pteam,
         );
 
-        return DBQueryInsert($query);
+        $moveId = DBQueryInsert($query);
+        CacheForgetNamespace('pool_moved_placings');
+        return $moveId;
     } else {
         die('Insufficient rights to add pool moves');
     }
@@ -1954,7 +1983,9 @@ function PoolSetMove($frompool, $oldfpos, $fromplacing, $torank)
             (int) $oldfpos,
         );
 
-        return DBQuery($query);
+        $result = DBQuery($query);
+        CacheForgetNamespace('pool_moved_placings');
+        return $result;
     } else {
         die('Insufficient rights to add pool moves');
     }
@@ -2156,6 +2187,7 @@ function PoolDeleteMove($frompool, $fromplacing)
         );
 
         DBQuery($query);
+        CacheForgetNamespace('pool_moved_placings');
     } else {
         die('Insufficient rights to move teams');
     }
@@ -2902,6 +2934,7 @@ function SeriesRanking($series_id)
     foreach ($ppools as $ppool) {
         $teams = PoolTeams($ppool['pool_id']);
         $steams = PoolSchedulingTeams($ppool['pool_id']);
+        $movedPlacings = PoolMovedPlacings($ppool['pool_id']);
         if (count($teams) < count($steams)) {
             $totalteams = count($steams);
         } else {
@@ -2909,8 +2942,7 @@ function SeriesRanking($series_id)
         }
 
         for ($i = 1; $i <= $totalteams; $i++) {
-            $moved = PoolMoveExist($ppool['pool_id'], $i);
-            if (!$moved) {
+            if (!isset($movedPlacings[$i])) {
                 $team = PoolTeamFromStandings($ppool['pool_id'], $i);
                 $gamesleft = 1;
                 if (isset($team['team_id'])) {

--- a/lib/season.functions.php
+++ b/lib/season.functions.php
@@ -3,6 +3,8 @@
 require_once __DIR__ . '/include_only.guard.php';
 denyDirectLibAccess(__FILE__);
 
+require_once __DIR__ . '/cache.functions.php';
+
 /**
  * @file
  * This file contains all event handling functions. For historical reasons event (tournament/season) is referred as a season.
@@ -75,6 +77,18 @@ function SeasonTypes()
 }
 
 /**
+ * Clear request-local season lookup caches after mutating season metadata.
+ *
+ * @return void
+ */
+function ClearSeasonRuntimeCache()
+{
+    CacheForgetNamespace('current_season');
+    CacheForgetNamespace('current_seasons');
+    CacheForgetNamespace('season_info');
+}
+
+/**
  * Returns current season, which can be user selected if multiple seasons set as current (uo_season.iscurrent=1).
  * User selected season is stored into $_SESSION['userproperties']['selseason']
  * @return String uo_season.season_id
@@ -84,8 +98,11 @@ function CurrentSeason()
     if (isset($_SESSION['userproperties']['selseason'])) {
         return $_SESSION['userproperties']['selseason'];
     }
-    $query = sprintf("SELECT season_id FROM uo_season WHERE iscurrent=1 ORDER BY starttime DESC");
-    return DBQueryToValue($query);
+
+    return CacheRemember('current_season', 'default', function () {
+        $query = sprintf("SELECT season_id FROM uo_season WHERE iscurrent=1 ORDER BY starttime DESC");
+        return DBQueryToValue($query);
+    });
 }
 
 /**
@@ -95,8 +112,10 @@ function CurrentSeason()
  */
 function CurrentSeasons()
 {
-    $query = sprintf("SELECT season_id AS season_id, name FROM uo_season WHERE iscurrent=1 ORDER BY starttime DESC");
-    return DBQueryToArray($query);
+    return CacheRemember('current_seasons', 'default', function () {
+        $query = sprintf("SELECT season_id AS season_id, name FROM uo_season WHERE iscurrent=1 ORDER BY starttime DESC");
+        return DBQueryToArray($query);
+    });
 }
 
 /**
@@ -156,16 +175,19 @@ function Seasontype($seasonId)
  */
 function SeasonInfo($seasonId)
 {
-    $query = sprintf(
-        "SELECT * FROM uo_season WHERE season_id='%s'",
-        DBEscapeString($seasonId),
-    );
-    $row = DBQueryToRow($query, true);
-    if (is_array($row) && !array_key_exists('spiritpoints', $row)) {
-        // Deprecated alias kept for live-skin backward compatibility; use spiritmode instead.
-        $row['spiritpoints'] = (int) (($row['spiritmode'] ?? 0) > 0);
-    }
-    return $row;
+    $seasonId = (string) $seasonId;
+    return CacheRemember('season_info', $seasonId, function () use ($seasonId) {
+        $query = sprintf(
+            "SELECT * FROM uo_season WHERE season_id='%s'",
+            DBEscapeString($seasonId),
+        );
+        $row = DBQueryToRow($query, true);
+        if (is_array($row) && !array_key_exists('spiritpoints', $row)) {
+            // Deprecated alias kept for live-skin backward compatibility; use spiritmode instead.
+            $row['spiritpoints'] = (int) (($row['spiritmode'] ?? 0) > 0);
+        }
+        return $row;
+    });
 }
 
 /**
@@ -201,10 +223,9 @@ function IsSeasonInMaintenance($seasonId)
     if (empty($seasonId)) {
         return false;
     }
-    return (bool) DBQueryToValue(sprintf(
-        "SELECT maintenance_mode FROM uo_season WHERE season_id='%s'",
-        DBEscapeString($seasonId),
-    ));
+
+    $seasonInfo = SeasonInfo($seasonId);
+    return !empty($seasonInfo['maintenance_mode']);
 }
 
 function CanBypassEventMaintenance($seasonId)
@@ -341,7 +362,11 @@ function SetEventReadonly($seasonId)
             "UPDATE uo_season SET event_readonly=1 WHERE season_id='%s'",
             DBEscapeString($seasonId),
         );
-        return DBExecute($query);
+        $result = DBExecute($query);
+        if ($result) {
+            ClearSeasonRuntimeCache();
+        }
+        return $result;
     } else {
         die('Insufficient rights to edit season');
     }
@@ -793,7 +818,11 @@ function DeleteSeason($seasonId)
             "DELETE FROM uo_season WHERE season_id='%s'",
             DBEscapeString($seasonId),
         );
-        return DBExecute($query);
+        $result = DBExecute($query);
+        if ($result) {
+            ClearSeasonRuntimeCache();
+        }
+        return $result;
     } else {
         die('Insufficient rights to delete season');
     }
@@ -877,6 +906,9 @@ function AddSeason($seasonId, $params, $comment = null)
 
         if ($result && isset($comment)) {
             SetComment(1, $seasonId, $comment);
+        }
+        if ($result) {
+            ClearSeasonRuntimeCache();
         }
         if ($result && function_exists('RefreshSeasonSpiritData')) {
             RefreshSeasonSpiritData($seasonId);
@@ -963,11 +995,14 @@ function SetSeason($seasonId, $params, $comment = null)
         );
 
         $result = DBExecute($query);
-        if ($result && function_exists('RefreshSeasonSpiritData')) {
-            RefreshSeasonSpiritData($seasonId);
-        }
         if (isset($comment) && $result) {
             SetComment(1, $seasonId, $comment);
+        }
+        if ($result) {
+            ClearSeasonRuntimeCache();
+        }
+        if ($result && function_exists('RefreshSeasonSpiritData')) {
+            RefreshSeasonSpiritData($seasonId);
         }
         return $result;
     } else {
@@ -1004,6 +1039,9 @@ function SetSeasonSpiritSettings($seasonId, $params)
     );
 
     $result = DBExecute($query);
+    if ($result) {
+        ClearSeasonRuntimeCache();
+    }
     if ($result && function_exists('RefreshSeasonSpiritData')) {
         RefreshSeasonSpiritData($seasonId);
     }

--- a/lib/season.functions.php
+++ b/lib/season.functions.php
@@ -83,7 +83,6 @@ function SeasonTypes()
  */
 function ClearSeasonRuntimeCache()
 {
-    CacheForgetNamespace('current_season');
     CacheForgetNamespace('current_seasons');
     CacheForgetNamespace('season_info');
 }
@@ -99,10 +98,12 @@ function CurrentSeason()
         return $_SESSION['userproperties']['selseason'];
     }
 
-    return CacheRemember('current_season', 'default', function () {
-        $query = sprintf("SELECT season_id FROM uo_season WHERE iscurrent=1 ORDER BY starttime DESC");
-        return DBQueryToValue($query);
-    });
+    $currentSeasons = CurrentSeasons();
+    if (empty($currentSeasons)) {
+        return "";
+    }
+
+    return $currentSeasons[0]['season_id'];
 }
 
 /**
@@ -126,16 +127,11 @@ function CurrentSeasons()
 function CurrentSeasonName()
 {
     if (isset($_SESSION['userproperties']['selseason'])) {
-        $query = sprintf(
-            "SELECT name FROM uo_season WHERE season_id='%s'",
-            DBEscapeString($_SESSION['userproperties']['selseason']),
-        );
-        $name = DBQueryToValue($query);
-        return $name === null ? "" : U_($name);
+        return SeasonName($_SESSION['userproperties']['selseason']);
     }
-    $query = sprintf("SELECT name FROM uo_season WHERE iscurrent=1 ORDER BY starttime DESC LIMIT 1");
-    $name = DBQueryToValue($query);
-    return $name === null ? "" : U_($name);
+
+    $seasonId = CurrentSeason();
+    return $seasonId === "" ? "" : SeasonName($seasonId);
 }
 
 /**
@@ -145,12 +141,12 @@ function CurrentSeasonName()
  */
 function SeasonName($seasonId)
 {
-    $query = sprintf(
-        "SELECT name FROM uo_season WHERE season_id='%s'",
-        DBEscapeString($seasonId),
-    );
-    $name = DBQueryToValue($query);
-    return ($name === null) ? "" : U_($name);
+    $seasonInfo = SeasonInfo($seasonId);
+    if (!is_array($seasonInfo) || !isset($seasonInfo['name'])) {
+        return "";
+    }
+
+    return U_($seasonInfo['name']);
 }
 
 /**
@@ -160,12 +156,12 @@ function SeasonName($seasonId)
  */
 function Seasontype($seasonId)
 {
-    $query = sprintf(
-        "SELECT type FROM uo_season WHERE season_id='%s'",
-        DBEscapeString($seasonId),
-    );
-    $type = DBQueryToValue($query);
-    return ($type === null) ? "" : $type;
+    $seasonInfo = SeasonInfo($seasonId);
+    if (!is_array($seasonInfo) || !isset($seasonInfo['type'])) {
+        return "";
+    }
+
+    return $seasonInfo['type'];
 }
 
 /**

--- a/lib/spirit.functions.php
+++ b/lib/spirit.functions.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/include_only.guard.php';
 denyDirectLibAccess(__FILE__);
 
+require_once __DIR__ . '/cache.functions.php';
 require_once __DIR__ . '/user.functions.php';
 
 function SpiritModeDisabledName()
@@ -129,11 +130,14 @@ function SpiritRequiredCategoryCount($mode)
     if ($mode <= 0) {
         return 0;
     }
-    return (int) DBQueryToValue(sprintf(
-        "SELECT COUNT(*) FROM uo_spirit_category
-		WHERE mode=%d AND `index` > 0",
-        $mode,
-    ));
+
+    return CacheRemember('spirit_required_category_count', $mode, function () use ($mode) {
+        return (int) DBQueryToValue(sprintf(
+            "SELECT COUNT(*) FROM uo_spirit_category
+			WHERE mode=%d AND `index` > 0",
+            $mode,
+        ));
+    });
 }
 
 function TeamSpiritSubmissionComplete($gameId, $teamId, $spiritmode = null)
@@ -349,14 +353,9 @@ function SpiritTokenGame($gameId, $teamId)
         return [];
     }
 
-    static $games = [];
-    $cacheKey = $gameId . ':' . $teamId;
-    if (array_key_exists($cacheKey, $games)) {
-        return $games[$cacheKey];
-    }
-
-    $query = sprintf(
-        "SELECT
+    return CacheRemember('spirit_token_game', [$gameId, $teamId], function () use ($gameId, $teamId) {
+        $query = sprintf(
+            "SELECT
 			g.game_id,
 			g.time,
 			g.hasstarted,
@@ -401,14 +400,14 @@ function SpiritTokenGame($gameId, $teamId)
 						AND uc.type IN (5, 6)
 				)
 			)",
-        $gameId,
-        $teamId,
-        $teamId,
-    );
+            $gameId,
+            $teamId,
+            $teamId,
+        );
 
-    $game = DBQueryToRow($query);
-    $games[$cacheKey] = $game ? $game : [];
-    return $games[$cacheKey];
+        $game = DBQueryToRow($query);
+        return $game ? $game : [];
+    });
 }
 
 function SpiritTokenRatedTeamId($game, $tokenTeamId)

--- a/lib/standings.functions.php
+++ b/lib/standings.functions.php
@@ -699,16 +699,16 @@ function TeamSeriesStanding($teamId)
     //loop all placement pools
     foreach ($ppools as $ppool) {
         $teams = PoolTeams($ppool['pool_id']);
+        $movedPlacings = PoolMovedPlacings($ppool['pool_id']);
         $i = 0;
         //loop all teams
         foreach ($teams as $team) {
             $i++;
-            $moved = PoolMoveExist($ppool['pool_id'], $i);
             //if not moved and team searched exit loop
-            if (!$moved && $team['team_id'] == $teamId) {
+            if (!isset($movedPlacings[$i]) && $team['team_id'] == $teamId) {
                 $found = true;
                 break;
-            } elseif (!$moved) {
+            } elseif (!isset($movedPlacings[$i])) {
                 $standing++;
             }
         }

--- a/lib/statistical.functions.php
+++ b/lib/statistical.functions.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/include_only.guard.php';
 denyDirectLibAccess(__FILE__);
 
+require_once __DIR__ . '/cache.functions.php';
 require_once __DIR__ . '/season.functions.php';
 require_once __DIR__ . '/standings.functions.php';
 require_once __DIR__ . '/player.functions.php';
@@ -20,7 +21,9 @@ function IsSeasonStatsCalculated($season)
 
 function IsStatsDataAvailable()
 {
-    return DBQueryToValue("SELECT 1 FROM uo_season_stats LIMIT 1");
+    return CacheRemember('stats_data_available', 'default', function () {
+        return DBQueryToValue("SELECT 1 FROM uo_season_stats LIMIT 1");
+    });
 }
 
 function DeleteSeasonStats($season)
@@ -32,6 +35,7 @@ function DeleteSeasonStats($season)
         DBQuery(sprintf("DELETE FROM uo_team_stats WHERE season='%s'", $season_safe));
         DBQuery(sprintf("DELETE FROM uo_team_spirit_stats WHERE season='%s'", $season_safe));
         DBQuery(sprintf("DELETE FROM uo_player_stats WHERE season='%s'", $season_safe));
+        CacheForgetNamespace('stats_data_available');
     } else {
         die('Insufficient rights to archive season');
     }
@@ -368,6 +372,7 @@ function CalcSeasonStats($season)
 				players=$played_players" . $defense_str .
             "WHERE season='" . $season_info['season_id'] . "'";
         DBQuery($query);
+        CacheForgetNamespace('stats_data_available');
     } else {
         die('Insufficient rights to archive season');
     }

--- a/lib/team.functions.php
+++ b/lib/team.functions.php
@@ -414,6 +414,12 @@ function TeamGetNextGames($teamId, $poolId)
 
 function TeamPoolGamesLeft($teamId, $poolId)
 {
+    $teamId = (int) $teamId;
+    $poolId = (int) $poolId;
+    if ($teamId <= 0 || $poolId <= 0) {
+        return [];
+    }
+
     $query = sprintf(
         "
 			SELECT pp.game_id, pp.hometeam, pp.visitorteam, pp.time
@@ -422,9 +428,9 @@ function TeamPoolGamesLeft($teamId, $poolId)
 			WHERE pps.pool='%s' AND pp.valid=true 
 				AND (pp.hasstarted=0 OR pp.isongoing=1) AND (hometeam=%d OR visitorteam=%d)					
 			ORDER BY pp.time ASC",
-        DBEscapeString($poolId),
-        DBEscapeString($teamId),
-        DBEscapeString($teamId),
+        $poolId,
+        $teamId,
+        $teamId,
     );
 
     return DBQueryToArray($query);

--- a/lib/team.functions.php
+++ b/lib/team.functions.php
@@ -39,6 +39,11 @@ function TeamPlayerList($teamId)
 
 function TeamName($teamId)
 {
+    $teamId = (string) $teamId;
+    if ($teamId === '' || (int) $teamId <= 0) {
+        return "";
+    }
+
     $query = sprintf(
         "SELECT name FROM uo_team WHERE team_id='%s'",
         DBEscapeString($teamId),

--- a/lib/user.functions.php
+++ b/lib/user.functions.php
@@ -879,7 +879,12 @@ function getTeamSeason($team)
 
 function getTeamName($team)
 {
-    $query = sprintf("SELECT name FROM uo_team WHERE team_id=%d", (int) $team);
+    $team = (int) $team;
+    if ($team <= 0) {
+        return "";
+    }
+
+    $query = sprintf("SELECT name FROM uo_team WHERE team_id=%d", $team);
     $result = DBQuery($query);
 
     if ($row = mysqli_fetch_assoc($result)) {

--- a/poolstatus.php
+++ b/poolstatus.php
@@ -703,6 +703,7 @@ function printPlayoffTree($seasoninfo, $poolinfo)
     $notemplate .= "<table width='100%'>\n";
 
     $template = str_replace("[placement]", _("Placement"), $template);
+    $movedPlacings = PoolMovedPlacings($pool['pool_id']);
     for ($i = 1; $i <= $totalteams; $i++) {
         $placementname = "";
         if (!isset($pool['pool_id'])) {
@@ -717,7 +718,7 @@ function printPlayoffTree($seasoninfo, $poolinfo)
         $teampart = "";
         $unknown = "";
 
-        if (!PoolMoveExist($pool['pool_id'], $i)) {
+        if (!isset($movedPlacings[$i])) {
             $placement = PoolPlacementString($pool['pool_id'], $i);
             $placementname = "<b>" . U_($placement) . "</b> ";
             if ($gamesleft == 0 && $hasPlacedTeam) {

--- a/teams.php
+++ b/teams.php
@@ -400,11 +400,11 @@ if ($list == "allteams" || $list == "byseeding") {
         if (!empty($missingSpirit)) {
             $missingList = array_values($missingSpirit);
             usort($missingList, function ($a, $b) {
-                $seriesCmp = strcasecmp($a['seriesname'], $b['seriesname']);
+                $seriesCmp = strcasecmp((string) $a['seriesname'], (string) $b['seriesname']);
                 if ($seriesCmp !== 0) {
                     return $seriesCmp;
                 }
-                return strcasecmp($a['teamname'], $b['teamname']);
+                return strcasecmp((string) $a['teamname'], (string) $b['teamname']);
             });
             $html .= "<div class='TableContainer3'>\n";
             $html .= "<h3>" . _("Missing spirit submissions") . "</h3>\n";


### PR DESCRIPTION
## Summary

- Bulk-load moved playoff placings per pool and reuse them in ranking/status placement loops instead of checking each placing with a separate query.
- Skip `TeamPoolGamesLeft()` queries for placeholder or invalid team/pool IDs.
- Make the missing-spirit sorter in `teams.php` null-safe for PHP's `strcasecmp()` deprecation.

## Impact

This reduces repeated `uo_moveteams` placement lookups during pool status and ranking rendering while keeping the broader pool/team helper caching out of scope. The cache used here is request-local and invalidated after move-shape writes in the same request.

## Validation

- Pre-commit hook ran PHP-CS-Fixer on 7 staged PHP files.
- Pre-commit hook ran PHPStan on 7 staged PHP files with no errors.
- During development, focused PHP syntax checks, PHP-CS-Fixer, PHPStan, and the DB access checker passed. The DB checker only reported existing legacy cursor-helper warnings.