### PR TITLE
Make uo_game_pool the single source of truth for game pool membership

### DIFF
--- a/docs/schedule.md
+++ b/docs/schedule.md
@@ -123,10 +123,12 @@ Home and away assignment for generated games is event-controlled through `uo_sea
 
 This setting affects generation previews and newly generated games only. It does not rewrite existing games, and it does not change manually added games.
 
-`uo_game_pool` has two relevant meanings in scheduling:
+`uo_game_pool` is the single source of truth for a game's pool membership. Each row associates one game with one pool, and the `timetable` flag distinguishes the two roles:
 
-- `timetable=1`: normal visible schedule membership
-- `timetable=0`: moved-game linkage into another pool
+- `timetable=1`: the owning / scheduled pool. Each game has exactly one such row, created when the game is generated or manually added. Pool, series, and season lookups all join through this row.
+- `timetable=0`: carryover linkage into a continuation pool (for example pool A → upper pool F). Zero or more such rows per game. They let pool- and team-level stats include results from earlier pools without duplicating the game itself.
+
+`uo_game` itself no longer carries a `pool` column.
 
 `admin/schedule.php` builds a drag-and-drop board from unscheduled games loaded through `UnscheduledPoolGameInfo()`, `UnscheduledSeriesGameInfo()`, or `UnscheduledSeasonGameInfo()`, and reservation columns loaded through `ReservationInfoArray()`.
 
@@ -192,8 +194,8 @@ The PDF layer in `cust/default/pdfschedule.php` uses the same timetable rowset, 
 
 The most important tables for schedule behavior are:
 
-- `uo_game`: the actual game row, including teams or placeholders, reservation, time, pool, score state, duration override, and related flags
-- `uo_game_pool`: visible and moved pool membership
+- `uo_game`: the actual game row, including teams or placeholders, reservation, time, score state, duration override, and related flags
+- `uo_game_pool`: single source of truth for the game-to-pool relationship; `timetable=1` is the owning pool, `timetable=0` is carryover membership in a continuation pool
 - `uo_reservation`: reservation group, field, season, and reservation time window
 - `uo_location`: venue identity used by reservations
 - `uo_pool`: pool type, ordering, default timeslot, color, and series linkage

--- a/lib/accreditation.functions.php
+++ b/lib/accreditation.functions.php
@@ -20,7 +20,8 @@ function SeasonUnaccredited($season)
 		LEFT JOIN uo_team pt ON (p.team=pt.team_id)
 		LEFT JOIN uo_reservation res ON (pp.reservation=res.id)
 		LEFT JOIN uo_location loc ON (res.location=loc.id)
-		LEFT JOIN uo_pool pool ON (pp.pool=pool.pool_id)
+		LEFT JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
+		LEFT JOIN uo_pool pool ON (pool.pool_id=gp.pool)
 		LEFT JOIN uo_series ser ON (pool.series=ser.series_id)
 	WHERE played.accredited=0 AND ser.season='%s'",
         DBEscapeString($season),

--- a/lib/data.functions.php
+++ b/lib/data.functions.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once __DIR__ . '/include_only.guard.php';
+require_once __DIR__ . '/game.functions.php';
 denyDirectLibAccess(__FILE__);
 
 /**
@@ -25,6 +26,7 @@ class EventDataXMLHandler
     public $uo_game = []; //game id mapping array
     public $uo_reservation = []; //reservation id mapping array
     public $followers = []; // pools with unresolved followers
+    public $legacy_game_pool = []; //fallback owner pool from legacy uo_game.POOL cell: new_game_id => new_pool_id
     public $mode; //import mode: 'add' or 'replace'
 
     /**
@@ -104,12 +106,13 @@ class EventDataXMLHandler
                 }
 
                 //uo_scheduling_name, referenced by either games or moves
-                $schedulings = DBQuery("SELECT sched.* FROM uo_scheduling_name sched 
+                $schedulings = DBQuery("SELECT sched.* FROM uo_scheduling_name sched
             LEFT JOIN uo_game game ON (sched.scheduling_id = game.scheduling_name_home OR sched.scheduling_id = game.scheduling_name_visitor)
-            LEFT JOIN uo_pool pool ON (game.pool = pool.pool_id)
+            LEFT JOIN uo_game_pool gp ON (gp.game = game.game_id AND gp.timetable = 1)
+            LEFT JOIN uo_pool pool ON (pool.pool_id = gp.pool)
             LEFT JOIN uo_moveteams mv ON (sched.scheduling_id = mv.scheduling_id)
             LEFT JOIN uo_pool pool2 ON (mv.frompool = pool2.pool_id OR mv.topool = pool2.pool_id)
-            WHERE pool2.series = $seriesId  OR pool.series = $seriesId 
+            WHERE pool2.series = $seriesId  OR pool.series = $seriesId
             GROUP BY scheduling_id");
                 while ($row = mysqli_fetch_assoc($schedulings)) {
                     $ret .= $this->RowToXML("uo_scheduling_name", $row);
@@ -127,7 +130,9 @@ class EventDataXMLHandler
                     }
 
                     //uo_game
-                    $games = DBQuery("SELECT * FROM uo_game WHERE pool='" . DBEscapeString($row['pool_id']) . "'");
+                    $games = DBQuery("SELECT g.* FROM uo_game g
+                        INNER JOIN uo_game_pool gp ON (gp.game = g.game_id AND gp.timetable = 1)
+                        WHERE gp.pool = '" . DBEscapeString($row['pool_id']) . "'");
                     while ($row = mysqli_fetch_assoc($games)) {
                         $ret .= $this->RowToXML("uo_game", $row, false);
 
@@ -243,6 +248,21 @@ class EventDataXMLHandler
             foreach ($this->followers as $pool => $follow) {
                 $query = "UPDATE uo_pool SET follower='" . ((int) $this->uo_pool[$follow]) . "' WHERE pool_id='$pool'";
                 DBQuery($query);
+            }
+
+            // Backfill timetable=1 uo_game_pool rows from legacy uo_game.POOL cells.
+            // Skip games that already received an explicit owner row from
+            // <uo_game_pool> elements during import; otherwise route through
+            // SetGamePool() so the "exactly one owner per game" invariant is
+            // upheld (it handles conflicting carryovers at the target pool).
+            foreach ($this->legacy_game_pool as $gameId => $poolId) {
+                $hasOwner = DBQueryToValue(sprintf(
+                    "SELECT 1 FROM uo_game_pool WHERE game=%d AND timetable=1 LIMIT 1",
+                    (int) $gameId,
+                ));
+                if (!$hasOwner) {
+                    SetGamePool((int) $gameId, (int) $poolId);
+                }
             }
 
             xml_parser_free($xmlparser);
@@ -418,9 +438,14 @@ class EventDataXMLHandler
                 if (!empty($row["RESERVATION"]) && isset($this->uo_reservation[$row["RESERVATION"]])) {
                     $row["RESERVATION"] = $this->uo_reservation[$row["RESERVATION"]];
                 }
-                if (!empty($row["POOL"])) {
-                    $row["POOL"] = $this->uo_pool[$row["POOL"]];
+                // Capture legacy POOL cell as a fallback owner pool; uo_game has no pool column.
+                $legacyPool = null;
+                if (isset($row["POOL"]) && !empty($row["POOL"]) && $row["POOL"] != "NULL") {
+                    if (isset($this->uo_pool[$row["POOL"]])) {
+                        $legacyPool = (int) $this->uo_pool[$row["POOL"]];
+                    }
                 }
+                unset($row["POOL"]);
                 if (!empty($row["SCHEDULING_NAME_HOME"]) && isset($this->uo_scheduling_name[$row["SCHEDULING_NAME_HOME"]])) {
                     $row["SCHEDULING_NAME_HOME"] = $this->uo_scheduling_name[$row["SCHEDULING_NAME_HOME"]];
                 }
@@ -431,6 +456,9 @@ class EventDataXMLHandler
                 $newId = $this->InsertRow($name, $row);
 
                 $this->uo_game[$key] = $newId;
+                if ($legacyPool !== null) {
+                    $this->legacy_game_pool[$newId] = $legacyPool;
+                }
                 break;
 
             case "uo_goal":
@@ -464,7 +492,15 @@ class EventDataXMLHandler
             case "uo_game_pool":
                 $row["GAME"] = $this->uo_game[$row["GAME"]];
                 $row["POOL"] = $this->uo_pool[$row["POOL"]];
-                $this->InsertRow($name, $row);
+                if (isset($row["TIMETABLE"]) && (int) $row["TIMETABLE"] === 1) {
+                    // Route owner rows through the upsert helper so any
+                    // earlier-imported owner row for this game is replaced and
+                    // a conflicting carryover at the same pool is promoted,
+                    // keeping the invariant intact even on malformed XML.
+                    SetGamePool((int) $row["GAME"], (int) $row["POOL"]);
+                } else {
+                    $this->InsertRow($name, $row);
+                }
                 break;
 
             case "uo_moveteams":
@@ -683,19 +719,20 @@ class EventDataXMLHandler
                 if (!empty($row["RESERVATION"]) && isset($this->uo_reservation[$row["RESERVATION"]])) {
                     $row["RESERVATION"] = $this->uo_reservation[$row["RESERVATION"]];
                 }
-                if (!empty($row["POOL"])) {
-                    $row["POOL"] = $this->uo_pool[$row["POOL"]];
+                // Capture legacy POOL cell as a fallback owner pool; uo_game has no pool column.
+                $legacyPool = null;
+                if (isset($row["POOL"]) && !empty($row["POOL"]) && $row["POOL"] != "NULL") {
+                    if (isset($this->uo_pool[$row["POOL"]])) {
+                        $legacyPool = (int) $this->uo_pool[$row["POOL"]];
+                    }
                 }
+                unset($row["POOL"]);
                 if (!empty($row["SCHEDULING_NAME_HOME"]) && isset($this->uo_scheduling_name[$row["SCHEDULING_NAME_HOME"]])) {
                     $row["SCHEDULING_NAME_HOME"] = $this->uo_scheduling_name[$row["SCHEDULING_NAME_HOME"]];
                 }
                 if (!empty($row["SCHEDULING_NAME_VISITOR"] && isset($this->uo_scheduling_name[$row["SCHEDULING_NAME_VISITOR"]]))) {
                     $row["SCHEDULING_NAME_VISITOR"] = $this->uo_scheduling_name[$row["SCHEDULING_NAME_VISITOR"]];
                 }
-
-                $newId = $this->InsertRow($name, $row);
-
-                $this->uo_game[$key] = $newId;
 
                 $cond = "game_id='" . $key . "'";
                 $query = "SELECT * FROM " . $name . " WHERE " . $cond;
@@ -704,9 +741,15 @@ class EventDataXMLHandler
                 if ($exist) {
                     $this->SetRow($name, $row, $cond);
                     $this->uo_game[$key] = $key;
+                    if ($legacyPool !== null) {
+                        $this->legacy_game_pool[$key] = $legacyPool;
+                    }
                 } else {
                     $newId = $this->InsertRow($name, $row);
                     $this->uo_game[$key] = $newId;
+                    if ($legacyPool !== null) {
+                        $this->legacy_game_pool[$newId] = $legacyPool;
+                    }
                 }
                 break;
 
@@ -779,14 +822,21 @@ class EventDataXMLHandler
                 $row["GAME"] = $this->uo_game[$row["GAME"]];
                 $row["POOL"] = $this->uo_pool[$row["POOL"]];
 
-                $cond = "game='" . $row["GAME"] . "' AND pool='" . $row["POOL"] . "'";
-                $query = "SELECT * FROM " . $name . " WHERE " . $cond;
-                $exist = DBQueryRowCount($query);
-
-                if ($exist) {
-                    $this->SetRow($name, $row, $cond);
+                if (isset($row["TIMETABLE"]) && (int) $row["TIMETABLE"] === 1) {
+                    // Owner rows must respect the single-owner-per-game
+                    // invariant even when a row at (game, pool) already
+                    // exists with a different timetable value.
+                    SetGamePool((int) $row["GAME"], (int) $row["POOL"]);
                 } else {
-                    $this->InsertRow($name, $row);
+                    $cond = "game='" . $row["GAME"] . "' AND pool='" . $row["POOL"] . "'";
+                    $query = "SELECT * FROM " . $name . " WHERE " . $cond;
+                    $exist = DBQueryRowCount($query);
+
+                    if ($exist) {
+                        $this->SetRow($name, $row, $cond);
+                    } else {
+                        $this->InsertRow($name, $row);
+                    }
                 }
 
                 break;

--- a/lib/database.php
+++ b/lib/database.php
@@ -9,7 +9,7 @@ denyDirectLibAccess(__FILE__);
  * Update this constant whenever you add a new `upgradeNN()` step in
  * `sql/upgrade_db.php`, and export the current schema from the upgraded database.
  */
-define('DB_VERSION', 91);
+define('DB_VERSION', 92);
 
 /**
  * Maximum age in seconds before an automatic upgrade lock is considered stale.

--- a/lib/game.functions.php
+++ b/lib/game.functions.php
@@ -1445,10 +1445,16 @@ function GameSetStartingTeam($gameId, $home)
 
 /**
  * Set the owning (timetable=1) pool for a game in uo_game_pool, guaranteeing
- * exactly one owner row. Removes any stale timetable=1 row pointing elsewhere
- * and promotes an existing timetable=0 carryover row if it happens to target
- * the same pool. Callers must have verified the appropriate edit-rights for
- * the destination pool's series before invoking.
+ * exactly one owner row. Promotes an existing timetable=0 carryover row at
+ * the same pool and removes any stale timetable=1 row pointing elsewhere.
+ * Callers must have verified the appropriate edit-rights for the destination
+ * pool's series before invoking.
+ *
+ * The insert runs before the delete inside a transaction, so a failure on the
+ * destination row (for example, an FK violation against uo_pool) rolls back
+ * cleanly and leaves the existing owner row in place. This protects against
+ * the game disappearing from owner-row joins that the rest of the schema
+ * now depends on.
  */
 function SetGamePool($gameId, $poolId)
 {
@@ -1457,17 +1463,28 @@ function SetGamePool($gameId, $poolId)
     if ($gameId <= 0 || $poolId <= 0) {
         return;
     }
-    DBQuery(sprintf(
-        "DELETE FROM uo_game_pool WHERE game=%d AND timetable=1 AND pool!=%d",
-        $gameId,
-        $poolId,
-    ));
-    DBQuery(sprintf(
-        "INSERT INTO uo_game_pool (game, pool, timetable) VALUES (%d, %d, 1)
-            ON DUPLICATE KEY UPDATE timetable=1",
-        $gameId,
-        $poolId,
-    ));
+    $previousExceptionMode = DBShouldThrowExceptions();
+    DBSetExceptionMode(true);
+    try {
+        DBQuery('START TRANSACTION');
+        DBQuery(sprintf(
+            "INSERT INTO uo_game_pool (game, pool, timetable) VALUES (%d, %d, 1)
+                ON DUPLICATE KEY UPDATE timetable=1",
+            $gameId,
+            $poolId,
+        ));
+        DBQuery(sprintf(
+            "DELETE FROM uo_game_pool WHERE game=%d AND timetable=1 AND pool!=%d",
+            $gameId,
+            $poolId,
+        ));
+        DBQuery('COMMIT');
+    } catch (Throwable $e) {
+        DBQuery('ROLLBACK');
+        DBSetExceptionMode($previousExceptionMode);
+        throw $e;
+    }
+    DBSetExceptionMode($previousExceptionMode);
 }
 
 function AddGame($params)

--- a/lib/game.functions.php
+++ b/lib/game.functions.php
@@ -10,8 +10,9 @@ function SeasonScoreCounter($seasonId = "")
 {
     $query = "SELECT COALESCE(SUM(game.homescore), 0) + COALESCE(SUM(game.visitorscore), 0) AS scores
 		FROM uo_game game
-		LEFT JOIN uo_pool pool ON(pool.pool_id=game.pool)
-		LEFT JOIN uo_series ser ON(pool.series=ser.series_id)";
+		INNER JOIN uo_game_pool gp ON (gp.game=game.game_id AND gp.timetable=1)
+		LEFT JOIN uo_pool pool ON (pool.pool_id=gp.pool)
+		LEFT JOIN uo_series ser ON (pool.series=ser.series_id)";
 
     if (!empty($seasonId)) {
         $query .= sprintf(" WHERE ser.season='%s'", DBEscapeString($seasonId));
@@ -28,7 +29,11 @@ function GameSetPools($games)
     if (empty($gameIds)) {
         return [];
     }
-    $query = "SELECT DISTINCT pool_id, p.name from uo_game g left join uo_pool p on (g.pool=p.pool_id) WHERE g.game_id in (";
+    $query = "SELECT DISTINCT p.pool_id, p.name
+        FROM uo_game g
+        INNER JOIN uo_game_pool gp ON (gp.game=g.game_id AND gp.timetable=1)
+        LEFT JOIN uo_pool p ON (p.pool_id=gp.pool)
+        WHERE g.game_id in (";
     $query .= implode(",", $gameIds);
     $query .= ") ORDER BY p.ordering ASC";
     $result = DBQuery($query);
@@ -66,21 +71,22 @@ function PoolGameSetResults($pool, $games)
 function GameResult($gameId)
 {
     $query = sprintf(
-        "SELECT time, k.name As hometeamname, v.name As visitorteamname, 
-        k.valid as homevalid, v.valid as visitorvalid, 
-        p.*, hspirit.mode AS spiritmode, hspirit.sotg AS homesotg, vspirit.sotg AS visitorsotg, s.name AS gamename
-    FROM uo_game AS p 
-    LEFT JOIN (SELECT ssc.game_id, ssc.team_id, sct.mode, SUM(value*factor) AS sotg 
-               FROM uo_spirit_score ssc 
-               LEFT JOIN uo_spirit_category sct ON (ssc.category_id = sct.category_id) 
+        "SELECT time, k.name As hometeamname, v.name As visitorteamname,
+        k.valid as homevalid, v.valid as visitorvalid,
+        p.*, gp.pool AS pool, hspirit.mode AS spiritmode, hspirit.sotg AS homesotg, vspirit.sotg AS visitorsotg, s.name AS gamename
+    FROM uo_game AS p
+    LEFT JOIN uo_game_pool gp ON (gp.game=p.game_id AND gp.timetable=1)
+    LEFT JOIN (SELECT ssc.game_id, ssc.team_id, sct.mode, SUM(value*factor) AS sotg
+               FROM uo_spirit_score ssc
+               LEFT JOIN uo_spirit_category sct ON (ssc.category_id = sct.category_id)
                GROUP BY game_id, team_id, sct.mode) AS hspirit
        ON (p.game_id = hspirit.game_id AND hspirit.team_id = p.hometeam)
-    LEFT JOIN (SELECT ssc.game_id, ssc.team_id, sct.mode, SUM(value*factor) AS sotg 
-               FROM uo_spirit_score ssc 
-               LEFT JOIN uo_spirit_category sct ON (ssc.category_id = sct.category_id) 
+    LEFT JOIN (SELECT ssc.game_id, ssc.team_id, sct.mode, SUM(value*factor) AS sotg
+               FROM uo_spirit_score ssc
+               LEFT JOIN uo_spirit_category sct ON (ssc.category_id = sct.category_id)
                GROUP BY game_id, team_id, sct.mode ) AS vspirit
        ON (p.game_id = vspirit.game_id AND vspirit.team_id = p.visitorteam)
-    LEFT JOIN uo_team As k ON (p.hometeam=k.team_id) 
+    LEFT JOIN uo_team As k ON (p.hometeam=k.team_id)
     LEFT JOIN uo_team AS v ON (p.visitorteam=v.team_id)
     LEFT JOIN uo_scheduling_name s ON(s.scheduling_id=p.name)
     WHERE p.game_id='%s'",
@@ -121,9 +127,10 @@ function GameHomeTeamResults($teamId, $poolId)
         "SELECT g.game_id, g.homescore, g.visitorscore, g.hasstarted, g.visitorteam, COALESCE(pm.goals,0) AS scoresheet,
 			sn.name AS gamename, g.isongoing, g.hasstarted, g.forfeit
 			FROM uo_game g
+			INNER JOIN uo_game_pool gp ON (gp.game=g.game_id AND gp.timetable=1)
 			LEFT JOIN (SELECT COUNT(*) AS goals, game FROM uo_goal GROUP BY game) AS pm ON (g.game_id=pm.game)
 			LEFT JOIN uo_scheduling_name sn ON(g.name=sn.scheduling_id)
-			WHERE g.hometeam=%d AND g.pool=%d
+			WHERE g.hometeam=%d AND gp.pool=%d
 			GROUP BY g.game_id",
         (int) $teamId,
         (int) $poolId,
@@ -134,11 +141,12 @@ function GameHomeTeamResults($teamId, $poolId)
 function GameHomePseudoTeamResults($schedulingId, $poolId)
 {
     $query = sprintf(
-        "SELECT g.game_id, g.homescore, g.visitorscore, g.hasstarted, g.visitorteam, 
+        "SELECT g.game_id, g.homescore, g.visitorscore, g.hasstarted, g.visitorteam,
 			sn.name AS gamename, g.isongoing, g.hasstarted
-			FROM uo_game g 
+			FROM uo_game g
+			INNER JOIN uo_game_pool gp ON (gp.game=g.game_id AND gp.timetable=1)
 			LEFT JOIN uo_scheduling_name sn ON(g.name=sn.scheduling_id)
-			WHERE g.scheduling_name_home=%d AND g.pool=%d
+			WHERE g.scheduling_name_home=%d AND gp.pool=%d
 			GROUP BY g.game_id",
         (int) $schedulingId,
         (int) $poolId,
@@ -152,8 +160,9 @@ function GameVisitorTeamResults($teamId, $poolId)
         "SELECT g.game_id, g.homescore, g.visitorscore, g.hasstarted, g.hometeam, COALESCE(pm.goals,0) AS scoresheet,
 			g.isongoing, g.forfeit
 			FROM uo_game g
+			INNER JOIN uo_game_pool gp ON (gp.game=g.game_id AND gp.timetable=1)
 			LEFT JOIN (SELECT COUNT(*) AS goals, game FROM uo_goal GROUP BY game) AS pm ON (g.game_id=pm.game)
-			WHERE g.visitorteam=%d AND g.pool=%d AND g.hasstarted>0 AND g.valid=1 AND isongoing=0
+			WHERE g.visitorteam=%d AND gp.pool=%d AND g.hasstarted>0 AND g.valid=1 AND g.isongoing=0
 			GROUP BY g.game_id",
         (int) $teamId,
         (int) $poolId,
@@ -186,9 +195,11 @@ function GameNameFromId($gameId)
 function GameSeries($gameId)
 {
     $query = sprintf(
-        "SELECT s.series 
-		FROM uo_game p left join uo_pool s on (p.pool=s.pool_id)  
-		WHERE game_id='%s'",
+        "SELECT s.series
+		FROM uo_game p
+		INNER JOIN uo_game_pool gp ON (gp.game=p.game_id AND gp.timetable=1)
+		LEFT JOIN uo_pool s ON (s.pool_id=gp.pool)
+		WHERE p.game_id='%s'",
         DBEscapeString($gameId),
     );
     $result = DBQueryToValue($query);
@@ -243,9 +254,9 @@ function GameAdmins($gameId)
 function GamePool($gameId)
 {
     $query = sprintf(
-        "SELECT pool 
-		FROM uo_game  
-		WHERE game_id=%d",
+        "SELECT pool
+		FROM uo_game_pool
+		WHERE game=%d AND timetable=1",
         (int) $gameId,
     );
     $result = DBQueryToValue($query);
@@ -282,10 +293,12 @@ function GameReservation($gameId)
 function GameSeason($gameId)
 {
     $query = sprintf(
-        "SELECT ser.season 
-		FROM uo_game p LEFT JOIN uo_pool s on (p.pool=s.pool_id)
- 			LEFT JOIN uo_series ser ON (s.series=ser.series_id)  
-		WHERE game_id=%d",
+        "SELECT ser.season
+		FROM uo_game p
+		INNER JOIN uo_game_pool gp ON (gp.game=p.game_id AND gp.timetable=1)
+		LEFT JOIN uo_pool s ON (s.pool_id=gp.pool)
+		LEFT JOIN uo_series ser ON (s.series=ser.series_id)
+		WHERE p.game_id=%d",
         (int) $gameId,
     );
     $result = DBQueryToValue($query);
@@ -423,16 +436,17 @@ function GameAll($limit = 50)
 {
     $limit = intval($limit);
     //common game query
-    $query = "SELECT pp.game_id, pp.time, pp.hometeam, pp.visitorteam, pp.homescore, 
-			pp.visitorscore, pp.pool AS pool, pool.name AS poolname, pool.timeslot,
+    $query = "SELECT pp.game_id, pp.time, pp.hometeam, pp.visitorteam, pp.homescore,
+			pp.visitorscore, gp.pool AS pool, pool.name AS poolname, pool.timeslot,
 			ps.series_id, ps.name AS seriesname, ps.season, s.name AS seasonname, ps.type, pr.fieldname, pr.reservationgroup,
-			pr.id AS reservation_id, pr.starttime, pr.endtime, pl.id AS place_id, 
+			pr.id AS reservation_id, pr.starttime, pr.endtime, pl.id AS place_id,
 			pl.name AS placename, pl.address, pp.isongoing, pp.hasstarted, home.name AS hometeamname, visitor.name AS visitorteamname,
 			phome.name AS phometeamname, pvisitor.name AS pvisitorteamname, pool.color, pgame.name AS gamename,
-			home.abbreviation AS homeshortname, visitor.abbreviation AS visitorshortname, homec.country_id AS homecountryid, 
+			home.abbreviation AS homeshortname, visitor.abbreviation AS visitorshortname, homec.country_id AS homecountryid,
 			homec.name AS homecountry, visitorc.country_id AS visitorcountryid, visitorc.name AS visitorcountry, s.timezone
-			FROM uo_game pp 
-			LEFT JOIN uo_pool pool ON (pool.pool_id=pp.pool) 
+			FROM uo_game pp
+			LEFT JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
+			LEFT JOIN uo_pool pool ON (pool.pool_id=gp.pool)
 			LEFT JOIN uo_series ps ON (pool.series=ps.series_id)
 			LEFT JOIN uo_season s ON (s.season_id=ps.season)
 			LEFT JOIN uo_reservation pr ON (pp.reservation=pr.id)
@@ -778,16 +792,17 @@ function GameTurnoversArray($gameId)
 function GameInfo($gameId)
 {
     $query = sprintf(
-        "SELECT game_id, hometeam, kj.name as hometeamname, kj.abbreviation as hometeamshortname, visitorteam, vj.name as visitorteamname, vj.abbreviation as visitorteamshortname, pp.pool as pool,
-			time, homescore, visitorscore, pool.timecap, pool.scorecap, pool.winningscore, pool.drawsallowed, pool.timeslot AS timeslot, 
+        "SELECT pp.game_id, hometeam, kj.name as hometeamname, kj.abbreviation as hometeamshortname, visitorteam, vj.name as visitorteamname, vj.abbreviation as visitorteamshortname, gp.pool as pool,
+			time, homescore, visitorscore, pool.timecap, pool.scorecap, pool.winningscore, pool.drawsallowed, pool.timeslot AS timeslot,
 			pp.timeslot AS gametimeslot, pool.series, pool.color, ser.season, ser.name AS seriesname,
 			pool.name AS poolname, phome.name AS phometeamname, pvisitor.name AS pvisitorteamname, pp.scheduling_name_home,
 			pp.scheduling_name_visitor, isongoing, hasstarted, pl.name AS placename, res.fieldname, sname.name AS gamename,
 			kj.valid as homevalid, vj.valid as visitorvalid
-		FROM uo_game pp 
-			left join uo_reservation res on (pp.reservation=res.id) 
+		FROM uo_game pp
+			LEFT JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
+			left join uo_reservation res on (pp.reservation=res.id)
 			LEFT JOIN uo_location pl ON (res.location=pl.id)
-			left join uo_pool pool on (pp.pool=pool.pool_id)
+			left join uo_pool pool on (pool.pool_id=gp.pool)
 			left join uo_series ser on (ser.series_id=pool.series)
 			left join uo_team kj on (pp.hometeam=kj.team_id)
 			left join uo_team vj on (pp.visitorteam=vj.team_id)
@@ -939,9 +954,10 @@ function SeasonForfeitGames($seasonId)
 		        po.pool_id, po.name AS poolname,
 		        se.series_id, se.name AS seriesname
 		 FROM uo_game g
+		 INNER JOIN uo_game_pool gp ON (gp.game=g.game_id AND gp.timetable=1)
 		 LEFT JOIN uo_team ht ON g.hometeam = ht.team_id
 		 LEFT JOIN uo_team vt ON g.visitorteam = vt.team_id
-		 LEFT JOIN uo_pool po ON g.pool = po.pool_id
+		 LEFT JOIN uo_pool po ON po.pool_id = gp.pool
 		 LEFT JOIN uo_series se ON po.series = se.series_id
 		 WHERE se.season = '%s' AND g.forfeit = 1
 		 ORDER BY g.time",
@@ -1427,33 +1443,51 @@ function GameSetStartingTeam($gameId, $home)
     }
 }
 
+/**
+ * Set the owning (timetable=1) pool for a game in uo_game_pool, guaranteeing
+ * exactly one owner row. Removes any stale timetable=1 row pointing elsewhere
+ * and promotes an existing timetable=0 carryover row if it happens to target
+ * the same pool. Callers must have verified the appropriate edit-rights for
+ * the destination pool's series before invoking.
+ */
+function SetGamePool($gameId, $poolId)
+{
+    $gameId = (int) $gameId;
+    $poolId = (int) $poolId;
+    if ($gameId <= 0 || $poolId <= 0) {
+        return;
+    }
+    DBQuery(sprintf(
+        "DELETE FROM uo_game_pool WHERE game=%d AND timetable=1 AND pool!=%d",
+        $gameId,
+        $poolId,
+    ));
+    DBQuery(sprintf(
+        "INSERT INTO uo_game_pool (game, pool, timetable) VALUES (%d, %d, 1)
+            ON DUPLICATE KEY UPDATE timetable=1",
+        $gameId,
+        $poolId,
+    ));
+}
+
 function AddGame($params)
 {
     $poolinfo = PoolInfo($params['pool']);
     if (hasEditGamesRight($poolinfo['series'])) {
         $query = sprintf(
             "INSERT INTO uo_game
-			(hometeam, visitorteam, reservation, time, pool, valid, respteam) 
-			VALUES ('%s', '%s', '%s', '%s', '%s', '%s', '%s')",
+			(hometeam, visitorteam, reservation, time, valid, respteam)
+			VALUES ('%s', '%s', '%s', '%s', '%s', '%s')",
             DBEscapeString($params['hometeam']),
             DBEscapeString($params['visitorteam']),
             DBEscapeString($params['reservation']),
             DBEscapeString($params['time']),
-            DBEscapeString($params['pool']),
             DBEscapeString($params['valid']),
             DBEscapeString($params['respteam']),
         );
 
         $id = DBQueryInsert($query);
-        $query = sprintf(
-            "INSERT INTO uo_game_pool
-			(game, pool, timetable) 
-			VALUES ('%s', '%s', 1)",
-            DBEscapeString($id),
-            DBEscapeString($params['pool']),
-        );
-
-        $result = DBQuery($query);
+        SetGamePool($id, $params['pool']);
 
         Log1("game", "add", $id);
         return $id;
@@ -1474,7 +1508,6 @@ function SetGame($gameId, $params)
             "scheduling_name_visitor",
             "reservation",
             "time",
-            "pool",
             "valid",
             "islive",
             "liveurl",
@@ -1503,6 +1536,11 @@ function SetGame($gameId, $params)
                 );
             }
             $result = DBQuery($query);
+        }
+
+        if (!empty($params['pool'])) {
+            SetGamePool($gameId, $params['pool']);
+            $result = true;
         }
 
         if (!empty($params['respteam'])) {
@@ -1743,17 +1781,19 @@ function PoolDeleteAllGames($poolId)
     $series = PoolSeries($poolId);
     if (hasEditGamesRight($series)) {
         Log1("game", "delete", $poolId, 0, "Delete pool games");
+        // Delete games owned by this pool first; FK CASCADE removes their uo_game_pool rows.
         $query = sprintf(
-            "DELETE FROM uo_game_pool
-        WHERE pool=%d",
-            $poolId,
+            "DELETE g FROM uo_game g
+                INNER JOIN uo_game_pool gp ON (gp.game=g.game_id AND gp.timetable=1)
+                WHERE gp.pool=%d",
+            (int) $poolId,
         );
         $result = DBQuery($query);
 
+        // Mop up remaining carryover (timetable=0) entries pointing at this pool.
         $query = sprintf(
-            "DELETE FROM uo_game 
-        WHERE pool=%d",
-            $poolId,
+            "DELETE FROM uo_game_pool WHERE pool=%d",
+            (int) $poolId,
         );
         $result = DBQuery($query);
 
@@ -1800,7 +1840,8 @@ function UnscheduledPoolGameInfo($poolId)
 
     $query = sprintf(
         "SELECT g.game_id FROM uo_game g
-		WHERE g.reservation IS NULL AND g.time IS NULL AND g.pool=%d
+		INNER JOIN uo_game_pool gp ON (gp.game=g.game_id AND gp.timetable=1)
+		WHERE g.reservation IS NULL AND g.time IS NULL AND gp.pool=%d
 		ORDER BY g.game_id",
         (int) $poolId,
     );
@@ -1819,7 +1860,8 @@ function UnscheduledSeriesGameInfo($seriesId)
 
     $query = sprintf(
         "SELECT g.game_id FROM uo_game g
-		LEFT JOIN uo_pool pool ON (pool.pool_id=g.pool)
+		INNER JOIN uo_game_pool gp ON (gp.game=g.game_id AND gp.timetable=1)
+		LEFT JOIN uo_pool pool ON (pool.pool_id=gp.pool)
 		WHERE g.reservation IS NULL AND g.time IS NULL AND pool.series=%d
 		ORDER BY pool.ordering, g.game_id",
         (int) $seriesId,
@@ -1839,7 +1881,8 @@ function UnscheduledSeasonGameInfo($seasonId)
 
     $query = sprintf(
         "SELECT g.game_id FROM uo_game g
-		LEFT JOIN uo_pool pool ON (pool.pool_id=g.pool)
+		INNER JOIN uo_game_pool gp ON (gp.game=g.game_id AND gp.timetable=1)
+		LEFT JOIN uo_pool pool ON (pool.pool_id=gp.pool)
 		LEFT JOIN uo_series ser ON (ser.series_id=pool.series)
 		WHERE g.reservation IS NULL AND g.time IS NULL AND ser.season='%s'
 		ORDER BY ser.ordering, pool.ordering, g.game_id",
@@ -1934,17 +1977,18 @@ function ResultsToCsv($season, $separator)
 {
 
     $query = sprintf(
-        "SELECT kj.name as Home, vj.name as Away, 
+        "SELECT kj.name as Home, vj.name as Away,
 			homescore AS HomeScores, visitorscore AS AwayScores, ser.name AS Division, pool.name AS Pool
-		FROM uo_game pp 
-			left join uo_reservation res on (pp.reservation=res.id) 
-			left join uo_pool pool on (pp.pool=pool.pool_id)
+		FROM uo_game pp
+			INNER JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
+			left join uo_reservation res on (pp.reservation=res.id)
+			left join uo_pool pool on (pool.pool_id=gp.pool)
 			left join uo_series ser on (ser.series_id=pool.series)
 			left join uo_team kj on (pp.hometeam=kj.team_id)
 			left join uo_team vj on (pp.visitorteam=vj.team_id)
 			LEFT JOIN uo_scheduling_name AS phome ON (pp.scheduling_name_home=phome.scheduling_id)
 			LEFT JOIN uo_scheduling_name AS pvisitor ON (pp.scheduling_name_visitor=pvisitor.scheduling_id)
-		WHERE ser.season='%s' AND (hasstarted>0)
+		WHERE ser.season='%s' AND (pp.hasstarted>0)
 		ORDER BY ser.ordering, pool.ordering, pp.time ASC, pp.game_id ASC",
         DBEscapeString($season),
     );

--- a/lib/player.functions.php
+++ b/lib/player.functions.php
@@ -553,14 +553,13 @@ function PlayerNumber($playerId, $gameId)
 function PlayerSeasonGames($playerId, $seasonId)
 {
     $query = sprintf(
-        "SELECT game_id,hometeam,visitorteam 
-		FROM uo_game p 
-		WHERE p.pool IN
-			(SELECT pool.pool_id 
-			FROM uo_pool pool 
-				LEFT JOIN uo_series ser ON (pool.series=ser.series_id) 
-			WHERE ser.season='%s') 
-		AND p.game_id IN (SELECT uo_goal.game FROM uo_goal 
+        "SELECT p.game_id,hometeam,visitorteam
+		FROM uo_game p
+		INNER JOIN uo_game_pool gp ON (gp.game=p.game_id AND gp.timetable=1)
+		LEFT JOIN uo_pool pool ON (pool.pool_id=gp.pool)
+		LEFT JOIN uo_series ser ON (pool.series=ser.series_id)
+		WHERE ser.season='%s'
+		AND p.game_id IN (SELECT uo_goal.game FROM uo_goal
 			WHERE scorer=%d OR assist=%d)
 		AND p.isongoing=0
 		ORDER BY p.time, p.game_id",
@@ -1170,12 +1169,13 @@ function PlayersToCsv($season, $separator)
 		LEFT JOIN uo_series AS divi ON(divi.series_id=j.series)
 		LEFT JOIN uo_country AS c ON(c.country_id=j.country)
 		LEFT JOIN uo_club AS club ON(club.club_id=j.club)
-		LEFT JOIN (SELECT up.player, COUNT(*) AS games 
+		LEFT JOIN (SELECT up.player, COUNT(*) AS games
 			FROM uo_played up
 			LEFT JOIN uo_game AS g4 ON (up.game=g4.game_id)
-			LEFT JOIN uo_pool pool ON(g4.pool=pool.pool_id)
+			INNER JOIN uo_game_pool gp4 ON (gp4.game=g4.game_id AND gp4.timetable=1)
+			LEFT JOIN uo_pool pool ON(pool.pool_id=gp4.pool)
 			LEFT JOIN uo_series ser ON(ser.series_id=pool.series)
-			WHERE ser.season='%s' AND g4.isongoing=0 
+			WHERE ser.season='%s' AND g4.isongoing=0
 			GROUP BY player) AS pel ON (p.player_id=pel.player)
 		WHERE divi.season='%s'
 		ORDER BY j.name, p.lastname, p.firstname", // FIXME g4.hasstarted>0??

--- a/lib/pool.functions.php
+++ b/lib/pool.functions.php
@@ -470,7 +470,8 @@ function PoolsScoreBoard($pools, $sorting, $limit)
         LEFT JOIN (SELECT up.player, COUNT(*) AS games
             FROM uo_played up
             LEFT JOIN uo_game AS g4 ON (up.game=g4.game_id)
-            WHERE g4.pool IN($poolList) AND g4.isongoing=0 GROUP BY player)
+            INNER JOIN uo_game_pool gp4 ON (gp4.game=g4.game_id AND gp4.timetable=1)
+            WHERE gp4.pool IN($poolList) AND g4.isongoing=0 GROUP BY player)
             AS pel ON (p.player_id=pel.player)
         WHERE pel.games > 0";
 
@@ -1196,10 +1197,10 @@ function PoolGetGamesToMove($poolId, $mvgames)
 
 function PoolCountGames($poolId)
 {
-    $games = DBQuery("SELECT game_id
+    $games = DBQuery("SELECT game.game_id
       FROM uo_game game
-      LEFT JOIN uo_pool p ON (p.pool_id=game.pool)
-      WHERE p.pool_id=$poolId");
+      INNER JOIN uo_game_pool gp ON (gp.game=game.game_id AND gp.timetable=1)
+      WHERE gp.pool=$poolId");
     return mysqli_num_rows($games);
 }
 
@@ -1220,18 +1221,18 @@ function PoolGames($poolId, $fieldId = null)
             phome.name AS phometeamname, pvisitor.name AS pvisitorteamname,
             ps.pool AS original_pool, pgame.name AS gamename
             FROM uo_game p
+            INNER JOIN uo_game_pool ps ON (p.game_id=ps.game AND ps.timetable=1)
             LEFT JOIN uo_team AS home ON (p.hometeam=home.team_id)
             LEFT JOIN uo_team AS visitor ON (p.visitorteam=visitor.team_id)
             LEFT JOIN uo_scheduling_name AS phome ON (p.scheduling_name_home=phome.scheduling_id)
             LEFT JOIN uo_scheduling_name AS pvisitor ON (p.scheduling_name_visitor=pvisitor.scheduling_id)
 	    LEFT JOIN uo_scheduling_name AS pgame ON (p.name=pgame.scheduling_id)
-            LEFT JOIN uo_game_pool ps ON (p.game_id=ps.game)
             WHERE ps.pool = %d",
         (int) $poolId,
     );
     if (isset($fieldId)) {
         $query .= sprintf(
-            " AND p.reservation = %d AND ps.timetable=1",
+            " AND p.reservation = %d",
             (int) $fieldId,
         );
     }
@@ -1254,13 +1255,13 @@ function PoolGamesNotScheduled($poolId)
         phome.name AS phometeamname, pvisitor.name AS pvisitorteamname,
         ps.pool AS original_pool, pgame.name AS gamename
         FROM uo_game p
+        INNER JOIN uo_game_pool ps ON (p.game_id=ps.game AND ps.timetable=1)
         LEFT JOIN uo_team AS home ON (p.hometeam=home.team_id)
         LEFT JOIN uo_team AS visitor ON (p.visitorteam=visitor.team_id)
         LEFT JOIN uo_scheduling_name AS phome ON (p.scheduling_name_home=phome.scheduling_id)
         LEFT JOIN uo_scheduling_name AS pvisitor ON (p.scheduling_name_visitor=pvisitor.scheduling_id)
 		LEFT JOIN uo_scheduling_name AS pgame ON (p.name=pgame.scheduling_id)
-        LEFT JOIN uo_game_pool ps ON (p.game_id=ps.game)
-        WHERE ps.pool = %d AND (p.time IS NULL OR p.reservation IS NULL) AND ps.timetable=1
+        WHERE ps.pool = %d AND (p.time IS NULL OR p.reservation IS NULL)
         ORDER BY game_id",
         (int) $poolId,
     );
@@ -1279,7 +1280,7 @@ function PoolMovedGames($poolId)
 {
     $query = sprintf(
         "SELECT pp.game_id, pp.time, pp.hometeam, pp.visitorteam, pp.homescore,
-            pp.visitorscore, pp.pool AS pool, pool.name AS poolname, pool.timeslot,
+            pp.visitorscore, gpo.pool AS pool, pool.name AS poolname, pool.timeslot,
             ps.series_id, ps.name AS seriesname, ps.season, ps.type, pr.fieldname, pr.reservationgroup,
             pr.id AS reservation_id, pr.starttime, pr.endtime, pl.id AS place_id, COALESCE(pm.goals,0) AS scoresheet,
             pl.name AS placename, pl.address, pp.isongoing, pp.hasstarted, home.name AS hometeamname, visitor.name AS visitorteamname,
@@ -1288,8 +1289,9 @@ function PoolMovedGames($poolId)
             homec.name AS homecountry, visitorc.country_id AS visitorcountryid, visitorc.name AS visitorcountry
             FROM uo_game_pool gp
             LEFT JOIN uo_game pp ON (gp.game=pp.game_id)
+            LEFT JOIN uo_game_pool gpo ON (gpo.game=pp.game_id AND gpo.timetable=1)
             LEFT JOIN (SELECT COUNT(*) AS goals, game FROM uo_goal GROUP BY game) AS pm ON (pp.game_id=pm.game)
-            LEFT JOIN uo_pool pool ON (pool.pool_id=pp.pool)
+            LEFT JOIN uo_pool pool ON (pool.pool_id=gpo.pool)
             LEFT JOIN uo_series ps ON (pool.series=ps.series_id)
             LEFT JOIN uo_reservation pr ON (pp.reservation=pr.id)
             LEFT JOIN uo_location pl ON (pr.location=pl.id)
@@ -1300,7 +1302,7 @@ function PoolMovedGames($poolId)
             LEFT JOIN uo_scheduling_name AS pgame ON (pp.name=pgame.scheduling_id)
             LEFT JOIN uo_scheduling_name AS phome ON (pp.scheduling_name_home=phome.scheduling_id)
             LEFT JOIN uo_scheduling_name AS pvisitor ON (pp.scheduling_name_visitor=pvisitor.scheduling_id)
-            WHERE pp.valid=true AND gp.pool=%d AND timetable=0
+            WHERE pp.valid=true AND gp.pool=%d AND gp.timetable=0
             ORDER BY pr.starttime, pr.reservationgroup, pl.id, pr.fieldname +0, pp.time ASC, pp.game_id ASC",
         (int) $poolId,
     );
@@ -1337,14 +1339,14 @@ function PoolTotalPlayedGames($poolId)
 function PoolResolvePlayed($poolId)
 {
     $poolId = intval($poolId);
-    $games = DBQuery("SELECT game_id
+    $games = DBQuery("SELECT game.game_id
             FROM uo_game game
-            LEFT JOIN uo_pool p ON (p.pool_id=game.pool)
-            WHERE p.pool_id=$poolId");
-    $played = DBQuery("SELECT game_id
+            INNER JOIN uo_game_pool gp ON (gp.game=game.game_id AND gp.timetable=1)
+            WHERE gp.pool=$poolId");
+    $played = DBQuery("SELECT game.game_id
             FROM uo_game game
-            LEFT JOIN uo_pool p ON (p.pool_id=game.pool)
-            WHERE p.pool_id=$poolId AND game.hasstarted AND game.isongoing=0");
+            INNER JOIN uo_game_pool gp ON (gp.game=game.game_id AND gp.timetable=1)
+            WHERE gp.pool=$poolId AND game.hasstarted AND game.isongoing=0");
     if (mysqli_num_rows($games) == mysqli_num_rows($played)) {
         DBQuery("UPDATE uo_pool SET played=1 WHERE pool_id=$poolId");
     } else {
@@ -1362,10 +1364,10 @@ function IsPoolStarted($poolId)
 {
 
     $query = sprintf(
-        "SELECT game_id
-            FROM uo_pool pool
-            LEFT JOIN uo_game pp ON (pool.pool_id=pp.pool)
-            WHERE pool.pool_id=$poolId AND (pp.hasstarted>0)",
+        "SELECT pp.game_id
+            FROM uo_game pp
+            INNER JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
+            WHERE gp.pool=%d AND pp.hasstarted>0",
         (int) $poolId,
     );
     return DBQueryRowCount($query) ? true : false;
@@ -2319,7 +2321,7 @@ function PoolSetSchedulingName($scheduling_id, $name, $season)
 function CanGenerateGames($poolId)
 {
     $query = sprintf(
-        "SELECT count(*) FROM uo_game WHERE pool=%d",
+        "SELECT count(*) FROM uo_game_pool WHERE pool=%d AND timetable=1",
         (int) $poolId,
     );
     return DBQueryToValue($query) == 0;
@@ -2359,7 +2361,7 @@ function CanDeletePool($poolId)
     $count = DBQueryToValue($query);
     if ($count == 0) {
         $query = sprintf(
-            "SELECT count(*) FROM uo_game WHERE pool=%d",
+            "SELECT count(*) FROM uo_game_pool WHERE pool=%d AND timetable=1",
             (int) $poolId,
         );
         $count = DBQueryToValue($query);
@@ -2387,7 +2389,9 @@ function CanDeletePool($poolId)
 function CanDeleteTeamFromPool($poolId, $teamId)
 {
     $query = sprintf(
-        "SELECT count(*) FROM uo_game WHERE pool=%d AND ((hometeam='%s' OR visitorteam='%s') AND (homescore>0 OR visitorscore>0 OR hasstarted>0))",
+        "SELECT count(*) FROM uo_game g
+            INNER JOIN uo_game_pool gp ON (gp.game=g.game_id AND gp.timetable=1)
+            WHERE gp.pool=%d AND ((g.hometeam='%s' OR g.visitorteam='%s') AND (g.homescore>0 OR g.visitorscore>0 OR g.hasstarted>0))",
         (int) $poolId,
         (int) $teamId,
         (int) $teamId,
@@ -2436,20 +2440,18 @@ function PoolAddGame($poolId, $home, $away, $psudoteams = false, $homeresp = fal
         if ($homeresp) {
 
             $query = sprintf(
-                "INSERT INTO uo_game ($hometeam, $visitorteam, pool, valid, respteam)
-                    values (%d, %d, %d, 1, %d)",
+                "INSERT INTO uo_game ($hometeam, $visitorteam, valid, respteam)
+                    values (%d, %d, 1, %d)",
                 (int) $home,
                 (int) $away,
-                (int) $poolId,
                 (int) $home,
             );
         } else {
             $query = sprintf(
-                "INSERT INTO uo_game ($hometeam, $visitorteam, pool, valid)
-                    values (%d, %d, %d, 1)",
+                "INSERT INTO uo_game ($hometeam, $visitorteam, valid)
+                    values (%d, %d, 1)",
                 (int) $home,
                 (int) $away,
-                (int) $poolId,
             );
         }
         $id = DBQueryInsert($query);
@@ -2775,39 +2777,35 @@ function GenerateGames($poolId, $rounds = 1, $generate = true, $nomutual = false
                     if ($homeresp) {
                         if ($pseudoteams) {
                             $query = sprintf(
-                                "INSERT INTO uo_game (scheduling_name_home, scheduling_name_visitor, pool, valid, respteam)
-                                    values (%d, %d, %d, 1, %d)",
+                                "INSERT INTO uo_game (scheduling_name_home, scheduling_name_visitor, valid, respteam)
+                                    values (%d, %d, 1, %d)",
                                 (int) $game['home'],
                                 (int) $game['away'],
-                                (int) $poolId,
                                 (int) $game['home'],
                             );
                         } else {
                             $query = sprintf(
-                                "INSERT INTO uo_game (hometeam, visitorteam, pool, valid, respteam)
-                                    values (%d, %d, %d, 1, %d)",
+                                "INSERT INTO uo_game (hometeam, visitorteam, valid, respteam)
+                                    values (%d, %d, 1, %d)",
                                 (int) $game['home'],
                                 (int) $game['away'],
-                                (int) $poolId,
                                 (int) $game['home'],
                             );
                         }
                     } else {
                         if ($pseudoteams) {
                             $query = sprintf(
-                                "INSERT INTO uo_game (scheduling_name_home, scheduling_name_visitor, pool, valid)
-                                    values (%d, %d, %d, 1)",
+                                "INSERT INTO uo_game (scheduling_name_home, scheduling_name_visitor, valid)
+                                    values (%d, %d, 1)",
                                 (int) $game['home'],
                                 (int) $game['away'],
-                                (int) $poolId,
                             );
                         } else {
                             $query = sprintf(
-                                "INSERT INTO uo_game (hometeam, visitorteam, pool, valid)
-                                    values (%d, %d, %d, 1)",
+                                "INSERT INTO uo_game (hometeam, visitorteam, valid)
+                                    values (%d, %d, 1)",
                                 (int) $game['home'],
                                 (int) $game['away'],
-                                (int) $poolId,
                             );
                         }
                     }

--- a/lib/reservation.functions.php
+++ b/lib/reservation.functions.php
@@ -65,13 +65,15 @@ function ReservationName($reservationInfo)
 function ReservationGames($placeId, $seasonId = "")
 {
     $query = sprintf("
-		SELECT game_id, hometeam, kj.name as hometeamname, visitorteam, vj.name as visitorteamname, pp.pool as pool,
-			time, homescore, visitorscore, pool.timecap, pool.timeslot, pp.timeslot as gametimeslot, pool.series, pool.color, 
+		SELECT pp.game_id, hometeam, kj.name as hometeamname, visitorteam, vj.name as visitorteamname, gp.pool as pool,
+			time, homescore, visitorscore, pool.timecap, pool.timeslot, pp.timeslot as gametimeslot, pool.series, pool.color,
 			CONCAT(ser.name, ', ', pool.name) as seriespoolname, ser.name AS seriesname, pool.name AS poolname,
 			loc.name AS locationname, res.fieldname,
 			phome.name AS phometeamname, pvisitor.name AS pvisitorteamname
-		FROM uo_game pp left join uo_reservation res on (pp.reservation=res.id) 
-			left join uo_pool pool on (pp.pool=pool.pool_id)
+		FROM uo_game pp
+			INNER JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
+			left join uo_reservation res on (pp.reservation=res.id)
+			left join uo_pool pool on (pool.pool_id=gp.pool)
 			left join uo_series ser on (pool.series=ser.series_id)
 			left join uo_location loc on (res.location=loc.id)
 			left join uo_team kj on (pp.hometeam=kj.team_id)
@@ -111,13 +113,15 @@ function ReservationGetGame($reservationId, $time = "")
 function ReservationGamesByField($fieldname, $seasonId = "")
 {
     $query = sprintf("
-		SELECT game_id, hometeam, kj.name as hometeamname, visitorteam, vj.name as visitorteamname, pp.pool as pool,
-			time, homescore, visitorscore, pool.timecap, pool.timeslot, pool.series, pool.color, 
+		SELECT pp.game_id, hometeam, kj.name as hometeamname, visitorteam, vj.name as visitorteamname, gp.pool as pool,
+			time, homescore, visitorscore, pool.timecap, pool.timeslot, pool.series, pool.color,
 			CONCAT(ser.name, ', ', pool.name) as seriespoolname, ser.name AS seriesname, pool.name AS poolname,
 			loc.name AS locationname, res.fieldname,
 			phome.name AS phometeamname, pvisitor.name AS pvisitorteamname
-		FROM uo_game pp left join uo_reservation res on (pp.reservation=res.id) 
-			left join uo_pool pool on (pp.pool=pool.pool_id)
+		FROM uo_game pp
+			INNER JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
+			left join uo_reservation res on (pp.reservation=res.id)
+			left join uo_pool pool on (pool.pool_id=gp.pool)
 			left join uo_series ser on (pool.series=ser.series_id)
 			left join uo_location loc on (res.location=loc.id)
 			left join uo_team kj on (pp.hometeam=kj.team_id)
@@ -142,8 +146,10 @@ function ReservationFields($seasonId)
     $query = sprintf(
         "
 		SELECT loc.name, res.fieldname
-			FROM uo_game pp left join uo_reservation res on (pp.reservation=res.id) 
-			left join uo_pool pool on (pp.pool=pool.pool_id)
+			FROM uo_game pp
+			INNER JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
+			left join uo_reservation res on (pp.reservation=res.id)
+			left join uo_pool pool on (pool.pool_id=gp.pool)
 			left join uo_series ser on (pool.series=ser.series_id)
 			left join uo_location loc on (res.location=loc.id)
 			left join uo_team kj on (pp.hometeam=kj.team_id)
@@ -162,14 +168,16 @@ function ReservationFields($seasonId)
 
 function ResponsibleReservationGames($placeId, $gameResponsibilities)
 {
-    $query = "SELECT game_id, hometeam, kj.name as hometeamname, visitorteam,
-			vj.name as visitorteamname, pp.pool as pool, time, homescore, visitorscore,
-			pool.timecap, pool.timeslot, pool.series, 
+    $query = "SELECT pp.game_id, hometeam, kj.name as hometeamname, visitorteam,
+			vj.name as visitorteamname, gp.pool as pool, time, homescore, visitorscore,
+			pool.timecap, pool.timeslot, pool.series,
 			ser.name as seriesname, pool.name as poolname,
 			loc.name as placename, res.fieldname,
 			phome.name AS phometeamname, pvisitor.name AS pvisitorteamname, pool.color, pgame.name AS gamename
-		FROM uo_game pp left join uo_reservation res on (pp.reservation=res.id) 
-			left join uo_pool pool on (pp.pool=pool.pool_id)
+		FROM uo_game pp
+			INNER JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
+			left join uo_reservation res on (pp.reservation=res.id)
+			left join uo_pool pool on (pool.pool_id=gp.pool)
 			left join uo_series ser on (pool.series=ser.series_id)
 			left join uo_location loc on (res.location=loc.id)
 			left join uo_team kj on (pp.hometeam=kj.team_id)
@@ -182,7 +190,7 @@ function ResponsibleReservationGames($placeId, $gameResponsibilities)
     } else {
         $query .= "WHERE res.id IS NULL";
     }
-    $query .= " AND game_id IN (" . implode(",", $gameResponsibilities) . ")
+    $query .= " AND pp.game_id IN (" . implode(",", $gameResponsibilities) . ")
 		ORDER BY pp.time ASC";
 
     return DBQueryToArray($query);
@@ -190,8 +198,9 @@ function ResponsibleReservationGames($placeId, $gameResponsibilities)
 
 function ReservationSeasons($reservationId)
 {
-    $query = sprintf("SELECT DISTINCT ser.season FROM uo_game p 
-		LEFT JOIN uo_pool pool ON (p.pool=pool.pool_id)
+    $query = sprintf("SELECT DISTINCT ser.season FROM uo_game p
+		INNER JOIN uo_game_pool gp ON (gp.game=p.game_id AND gp.timetable=1)
+		LEFT JOIN uo_pool pool ON (pool.pool_id=gp.pool)
 		LEFT JOIN uo_series ser ON (pool.series=ser.series_id)
 		WHERE p.reservation=%d", (int) $reservationId);
     $rows = DBQueryToArray($query);

--- a/lib/search.functions.php
+++ b/lib/search.functions.php
@@ -807,12 +807,14 @@ function GameResults()
     if (empty($_POST['searchgame'])) {
         return "";
     } else {
-        $query = "SELECT game_id, hometeam, kj.name as hometeamname, visitorteam, vj.name as visitorteamname, pp.pool as pool,
+        $query = "SELECT pp.game_id, hometeam, kj.name as hometeamname, visitorteam, vj.name as visitorteamname, gp.pool as pool,
 			time, homescore, visitorscore, pool.timecap, pool.timeslot, pool.series,
 			loc.name AS locationname, res.fieldname,
 			res.reservationgroup,phome.name AS phometeamname, pvisitor.name AS pvisitorteamname
-		FROM uo_game pp left join uo_reservation res on (pp.reservation=res.id) 
-			left join uo_pool pool on (pp.pool=pool.pool_id)
+		FROM uo_game pp
+			INNER JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
+			left join uo_reservation res on (pp.reservation=res.id)
+			left join uo_pool pool on (pool.pool_id=gp.pool)
 			left join uo_team kj on (pp.hometeam=kj.team_id)
 			left join uo_team vj on (pp.visitorteam=vj.team_id)
 			LEFT JOIN uo_scheduling_name AS phome ON (pp.scheduling_name_home=phome.scheduling_id)

--- a/lib/season.functions.php
+++ b/lib/season.functions.php
@@ -258,7 +258,8 @@ function MaintenanceSeasonFromView($rawView)
         return DBQueryToValue(sprintf(
             "SELECT ser.season
        FROM uo_game game
-       LEFT JOIN uo_pool pool ON (pool.pool_id=game.pool)
+       INNER JOIN uo_game_pool gp ON (gp.game=game.game_id AND gp.timetable=1)
+       LEFT JOIN uo_pool pool ON (pool.pool_id=gp.pool)
        LEFT JOIN uo_series ser ON (ser.series_id=pool.series)
        WHERE game.game_id=%d",
             (int) iget("game"),
@@ -600,11 +601,11 @@ function SeasonGamesNotScheduled($seasonId)
 			p.game_id IN (SELECT DISTINCT game FROM uo_goal) As goals,
 			Kj.team_id AS kId, Vj.team_id AS vId,phome.name AS phometeamname, pvisitor.name AS pvisitorteamname,
 			ps.name AS poolname, ser.name AS seriesname
-		FROM uo_game p 
+		FROM uo_game p
+		INNER JOIN uo_game_pool pss ON (pss.game=p.game_id AND pss.timetable=1)
 		LEFT JOIN uo_team AS Kj ON (p.hometeam=Kj.team_id)
 		LEFT JOIN uo_team AS Vj ON (p.visitorteam=Vj.team_id)
-		LEFT JOIN uo_game_pool pss ON (p.game_id=pss.game) 
-		LEFT JOIN uo_pool ps ON (p.pool=ps.pool_id)
+		LEFT JOIN uo_pool ps ON (ps.pool_id=pss.pool)
 		LEFT JOIN uo_series ser ON (ps.series=ser.series_id)
 		LEFT JOIN uo_scheduling_name AS phome ON (p.scheduling_name_home=phome.scheduling_id)
 		LEFT JOIN uo_scheduling_name AS pvisitor ON (p.scheduling_name_visitor=pvisitor.scheduling_id)
@@ -626,8 +627,9 @@ function SeasonAllGames($season)
     $query = sprintf(
         "
 		SELECT game.*
-		FROM uo_game game 
-		LEFT JOIN uo_pool pool ON (pool.pool_id=game.pool) 
+		FROM uo_game game
+		INNER JOIN uo_game_pool gp ON (gp.game=game.game_id AND gp.timetable=1)
+		LEFT JOIN uo_pool pool ON (pool.pool_id=gp.pool)
 		LEFT JOIN uo_series ser ON (ser.series_id=pool.series)
 		WHERE ser.season='%s'
 		ORDER BY game.game_id",

--- a/lib/series.functions.php
+++ b/lib/series.functions.php
@@ -329,13 +329,14 @@ function SeriesScoreBoard($seriesId, $sorting, $limit)
 			LEFT JOIN uo_game AS g3 ON (ps2.game=g3.game_id)
 			LEFT JOIN uo_pool pool ON(ps2.pool=pool.pool_id)
 			WHERE pool.series=%d AND ps2.timetable=1 AND g3.isongoing=0 GROUP BY assist) AS s ON (p.player_id=s.assist) 
-		LEFT JOIN uo_team AS j ON (p.team=j.team_id) 
-		LEFT JOIN (SELECT up.player, COUNT(*) AS games 
+		LEFT JOIN uo_team AS j ON (p.team=j.team_id)
+		LEFT JOIN (SELECT up.player, COUNT(*) AS games
 			FROM uo_played up
 			LEFT JOIN uo_game AS g4 ON (up.game=g4.game_id)
-			LEFT JOIN uo_pool pool ON(g4.pool=pool.pool_id)
-			WHERE pool.series=%d AND g4.isongoing=0 
-			GROUP BY player) AS pel ON (p.player_id=pel.player) 
+			INNER JOIN uo_game_pool gp4 ON (gp4.game=g4.game_id AND gp4.timetable=1)
+			LEFT JOIN uo_pool pool ON(pool.pool_id=gp4.pool)
+			WHERE pool.series=%d AND g4.isongoing=0
+			GROUP BY player) AS pel ON (p.player_id=pel.player)
 		WHERE pel.games > 0 AND j.series=%d",
         (int) $seriesId,
         (int) $seriesId,
@@ -421,13 +422,14 @@ function SeriesDefenseBoard($seriesId, $sorting, $limit)
 			LEFT JOIN uo_pool pool ON(ps.pool=pool.pool_id)
 			LEFT JOIN uo_game AS g1 ON (ps.game=g1.game_id)
 			WHERE pool.series=%d AND ps.timetable=1 AND g1.isongoing=0 GROUP BY author) AS t ON (p.player_id=t.author) 
-		LEFT JOIN uo_team AS j ON (p.team=j.team_id) 
-		LEFT JOIN (SELECT up.player, COUNT(*) AS games 
+		LEFT JOIN uo_team AS j ON (p.team=j.team_id)
+		LEFT JOIN (SELECT up.player, COUNT(*) AS games
 			FROM uo_played up
 			LEFT JOIN uo_game AS g4 ON (up.game=g4.game_id)
-			LEFT JOIN uo_pool pool ON(g4.pool=pool.pool_id)
-			WHERE pool.series=%d AND g4.isongoing=0 
-			GROUP BY player) AS pel ON (p.player_id=pel.player) 
+			INNER JOIN uo_game_pool gp4 ON (gp4.game=g4.game_id AND gp4.timetable=1)
+			LEFT JOIN uo_pool pool ON(pool.pool_id=gp4.pool)
+			WHERE pool.series=%d AND g4.isongoing=0
+			GROUP BY player) AS pel ON (p.player_id=pel.player)
 		WHERE pel.games > 0 AND j.series=%d",
         (int) $seriesId,
         (int) $seriesId,

--- a/lib/spirit.functions.php
+++ b/lib/spirit.functions.php
@@ -115,7 +115,8 @@ function SpiritGameRow($gameId)
 			se.lockteamspiritonsubmit,
 			se.event_readonly
 		FROM uo_game g
-		LEFT JOIN uo_pool p ON (p.pool_id = g.pool)
+		LEFT JOIN uo_game_pool gp ON (gp.game = g.game_id AND gp.timetable = 1)
+		LEFT JOIN uo_pool p ON (p.pool_id = gp.pool)
 		LEFT JOIN uo_series s ON (s.series_id = p.series)
 		LEFT JOIN uo_season se ON (se.season_id = s.season)
 		WHERE g.game_id=%d",
@@ -319,7 +320,8 @@ function SpiritTokenGameRows($teamId)
 		FROM uo_game g
 		LEFT JOIN uo_team th ON (th.team_id = g.hometeam)
 		LEFT JOIN uo_team tv ON (tv.team_id = g.visitorteam)
-		LEFT JOIN uo_pool p ON (p.pool_id = g.pool)
+		LEFT JOIN uo_game_pool gp ON (gp.game = g.game_id AND gp.timetable = 1)
+		LEFT JOIN uo_pool p ON (p.pool_id = gp.pool)
 		LEFT JOIN uo_series s ON (s.series_id = p.series)
 		LEFT JOIN uo_season se ON (se.season_id = s.season)
 		WHERE (g.hometeam=%d OR g.visitorteam=%d)
@@ -380,7 +382,8 @@ function SpiritTokenGame($gameId, $teamId)
 		FROM uo_game g
 		LEFT JOIN uo_team th ON (th.team_id = g.hometeam)
 		LEFT JOIN uo_team tv ON (tv.team_id = g.visitorteam)
-		LEFT JOIN uo_pool p ON (p.pool_id = g.pool)
+		LEFT JOIN uo_game_pool gp ON (gp.game = g.game_id AND gp.timetable = 1)
+		LEFT JOIN uo_pool p ON (p.pool_id = gp.pool)
 		LEFT JOIN uo_series s ON (s.series_id = p.series)
 		LEFT JOIN uo_season se ON (se.season_id = s.season)
 		WHERE g.game_id=%d
@@ -967,7 +970,8 @@ function RefreshSeasonSpiritVisibility($seasonId)
     $query = sprintf(
         "SELECT g.game_id
 		FROM uo_game g
-		LEFT JOIN uo_pool p ON (p.pool_id = g.pool)
+		LEFT JOIN uo_game_pool gp ON (gp.game = g.game_id AND gp.timetable = 1)
+		LEFT JOIN uo_pool p ON (p.pool_id = gp.pool)
 		LEFT JOIN uo_series s ON (s.series_id = p.series)
 		WHERE s.season='%s'",
         DBEscapeString($seasonId),
@@ -1126,7 +1130,8 @@ function SpiritToolRowsBySeason($season)
 		FROM uo_spirit_score ssc
 		LEFT JOIN uo_spirit_category sct ON (sct.category_id = ssc.category_id)
 		LEFT JOIN uo_game g ON (g.game_id = ssc.game_id)
-		LEFT JOIN uo_pool p ON (p.pool_id = g.pool)
+		LEFT JOIN uo_game_pool gp ON (gp.game = g.game_id AND gp.timetable = 1)
+		LEFT JOIN uo_pool p ON (p.pool_id = gp.pool)
 		LEFT JOIN uo_series s ON (s.series_id = p.series)
 		LEFT JOIN uo_team th ON (th.team_id = g.hometeam)
 		LEFT JOIN uo_team tv ON (tv.team_id = g.visitorteam)
@@ -1158,7 +1163,8 @@ function SpiritTimeoutSummaryBySeason($season)
 			COALESCE(SUM(CASE WHEN st.ishome = 0 THEN 1 ELSE 0 END), 0) AS away_total
 		FROM uo_spirit_timeout st
 		LEFT JOIN uo_game g ON (g.game_id = st.game)
-		LEFT JOIN uo_pool p ON (p.pool_id = g.pool)
+		LEFT JOIN uo_game_pool gp ON (gp.game = g.game_id AND gp.timetable = 1)
+		LEFT JOIN uo_pool p ON (p.pool_id = gp.pool)
 		LEFT JOIN uo_series s ON (s.series_id = p.series)
 		WHERE s.season='%s'",
         DBEscapeString($season),
@@ -1250,7 +1256,8 @@ function SpiritTimeoutGameRowsBySeason($season)
 			COUNT(*) AS total
 		FROM uo_spirit_timeout st
 		LEFT JOIN uo_game g ON (g.game_id = st.game)
-		LEFT JOIN uo_pool p ON (p.pool_id = g.pool)
+		LEFT JOIN uo_game_pool gp ON (gp.game = g.game_id AND gp.timetable = 1)
+		LEFT JOIN uo_pool p ON (p.pool_id = gp.pool)
 		LEFT JOIN uo_series s ON (s.series_id = p.series)
 		LEFT JOIN uo_team th ON (th.team_id = g.hometeam)
 		LEFT JOIN uo_team tv ON (tv.team_id = g.visitorteam)
@@ -1352,10 +1359,11 @@ function SpiritMissingGamesByPool($poolId)
 		FROM uo_game AS g
 		JOIN uo_team AS th ON (g.hometeam=th.team_id)
 		JOIN uo_team AS tv ON (g.visitorteam=tv.team_id)
-		LEFT JOIN uo_pool p ON (p.pool_id = g.pool)
+		LEFT JOIN uo_game_pool gp ON (gp.game = g.game_id AND gp.timetable = 1)
+		LEFT JOIN uo_pool p ON (p.pool_id = gp.pool)
 		LEFT JOIN uo_series s ON (s.series_id = p.series)
 		LEFT JOIN uo_season se ON (se.season_id = s.season)
-		WHERE g.pool=%d
+		WHERE gp.pool=%d
 			AND g.isongoing=0
 			AND (COALESCE(g.homescore,0)+COALESCE(g.visitorscore,0))>0
 		ORDER BY g.time ASC",
@@ -1381,7 +1389,8 @@ function SpiritMissingGamesBySeries($seriesId)
 		FROM uo_game AS g
 		JOIN uo_team AS th ON (g.hometeam=th.team_id)
 		JOIN uo_team AS tv ON (g.visitorteam=tv.team_id)
-		JOIN uo_pool AS p ON g.pool=p.pool_id
+		INNER JOIN uo_game_pool gp ON (gp.game = g.game_id AND gp.timetable = 1)
+		JOIN uo_pool AS p ON p.pool_id = gp.pool
 		LEFT JOIN uo_series s ON (s.series_id = p.series)
 		LEFT JOIN uo_season se ON (se.season_id = s.season)
 		WHERE p.series=%d
@@ -1675,7 +1684,8 @@ function SpiritTeamPointRows($seasonId, $teamId, $received = true)
 			tv.name AS visitorname,
 			se.spiritmode
 		FROM uo_game g
-		LEFT JOIN uo_pool p ON (p.pool_id = g.pool)
+		LEFT JOIN uo_game_pool gp ON (gp.game = g.game_id AND gp.timetable = 1)
+		LEFT JOIN uo_pool p ON (p.pool_id = gp.pool)
 		LEFT JOIN uo_series s ON (s.series_id = p.series)
 		LEFT JOIN uo_season se ON (se.season_id = s.season)
 		LEFT JOIN uo_team th ON (th.team_id = g.hometeam)

--- a/lib/standings.functions.php
+++ b/lib/standings.functions.php
@@ -444,14 +444,14 @@ function ResolveSeriesPoolStandings($poolId)
     }
 
     //test if pool is played
-    $games = DBQueryRowCount("SELECT game_id
+    $games = DBQueryRowCount("SELECT game.game_id
 		FROM uo_game game
-		LEFT JOIN uo_pool p ON (p.pool_id=game.pool)
-		WHERE p.pool_id=$poolId");
-    $played = DBQueryRowCount("SELECT game_id
+		INNER JOIN uo_game_pool gp ON (gp.game=game.game_id AND gp.timetable=1)
+		WHERE gp.pool=$poolId");
+    $played = DBQueryRowCount("SELECT game.game_id
 		FROM uo_game game
-		LEFT JOIN uo_pool p ON (p.pool_id=game.pool)
-		WHERE p.pool_id=$poolId AND (game.hasstarted>0) AND game.isongoing=0");
+		INNER JOIN uo_game_pool gp ON (gp.game=game.game_id AND gp.timetable=1)
+		WHERE gp.pool=$poolId AND (game.hasstarted>0) AND game.isongoing=0");
     if ($games == $played) {
 
         //test that standings are not shared

--- a/lib/swissdraw.functions.php
+++ b/lib/swissdraw.functions.php
@@ -425,11 +425,12 @@ function CheckBYESchedule($poolId)
 
     $query = sprintf(
         "
-		SELECT game_id,hometeam,visitorteam,reservation,g.time
-		FROM uo_game AS g 
+		SELECT g.game_id,hometeam,visitorteam,reservation,g.time
+		FROM uo_game AS g
+		INNER JOIN uo_game_pool gp ON (gp.game=g.game_id AND gp.timetable=1)
 		LEFT JOIN uo_team AS tvisit ON (g.visitorteam = tvisit.team_id)
 		LEFT JOIN uo_team as thome  ON (g.hometeam = thome.team_id)
-		WHERE g.pool='%s' AND ((thome.valid=2 OR tvisit.valid=2 AND g.time is not NULL) OR 
+		WHERE gp.pool='%s' AND ((thome.valid=2 OR tvisit.valid=2 AND g.time is not NULL) OR
 			(g.time is NULL AND thome.valid=1 AND tvisit.valid=1) )
 		ORDER BY g.time",
         DBEscapeString($poolId),
@@ -481,8 +482,11 @@ function CheckBYE($poolId)
         // if the visitor-team is the BYE-team assign the appropriate scores to home and visitor
         $query = sprintf(
             "
-				UPDATE uo_game,uo_team SET uo_game.visitorscore='%s', uo_game.homescore='%s', uo_game.hasstarted='2'
-				WHERE (uo_game.pool='%s' AND uo_game.visitorteam=uo_team.team_id AND uo_team.valid=2)",
+				UPDATE uo_game
+				INNER JOIN uo_game_pool gp ON (gp.game=uo_game.game_id AND gp.timetable=1)
+				INNER JOIN uo_team ON (uo_game.visitorteam=uo_team.team_id)
+				SET uo_game.visitorscore='%s', uo_game.homescore='%s', uo_game.hasstarted='2'
+				WHERE gp.pool='%s' AND uo_team.valid=2",
             DBEscapeString($poolInfo['forfeitagainst']),
             DBEscapeString($poolInfo['forfeitscore']),
             DBEscapeString($poolId),
@@ -493,8 +497,11 @@ function CheckBYE($poolId)
         // if the home-team is the BYE-team assign the appropriate scores to home and visitor
         $query = sprintf(
             "
-				UPDATE uo_game,uo_team SET uo_game.homescore='%s', uo_game.visitorscore='%s', uo_game.hasstarted='2'
-				WHERE (uo_game.pool='%s' AND uo_game.hometeam=uo_team.team_id AND uo_team.valid=2)",
+				UPDATE uo_game
+				INNER JOIN uo_game_pool gp ON (gp.game=uo_game.game_id AND gp.timetable=1)
+				INNER JOIN uo_team ON (uo_game.hometeam=uo_team.team_id)
+				SET uo_game.homescore='%s', uo_game.visitorscore='%s', uo_game.hasstarted='2'
+				WHERE gp.pool='%s' AND uo_team.valid=2",
             DBEscapeString($poolInfo['forfeitagainst']),
             DBEscapeString($poolInfo['forfeitscore']),
             DBEscapeString($poolId),

--- a/lib/team.functions.php
+++ b/lib/team.functions.php
@@ -274,14 +274,15 @@ function TeamGames($teamId)
         $defense_str = ",pp.homedefenses,pp.visitordefenses ";
     }
     $query = sprintf(
-        "SELECT pp.game_id, pp.hometeam, pp.visitorteam, pp.homescore, pp.visitorscore, 
-  				pp.hasstarted, pp.pool, ser.season AS season_id, ps.name, ser.name AS seriesname, pjs.activerank" . $defense_str .
-        "FROM uo_game pp 
-				LEFT JOIN uo_pool ps ON (ps.pool_id=pp.pool)
+        "SELECT pp.game_id, pp.hometeam, pp.visitorteam, pp.homescore, pp.visitorscore,
+					pp.hasstarted, gp.pool AS pool, ser.season AS season_id, ps.name, ser.name AS seriesname, pjs.activerank" . $defense_str .
+        "FROM uo_game pp
+				INNER JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
+				LEFT JOIN uo_pool ps ON (ps.pool_id=gp.pool)
 				LEFT JOIN uo_series ser ON (ps.series=ser.series_id)
-				LEFT JOIN uo_team_pool pjs ON(pp.pool=pjs.pool AND pjs.team='%s') WHERE pp.valid=true 
+				LEFT JOIN uo_team_pool pjs ON(gp.pool=pjs.pool AND pjs.team='%s') WHERE pp.valid=true
 					AND (pp.visitorteam='%s' OR pp.hometeam='%s') AND (pp.hasstarted>0)
-				ORDER BY pp.pool",
+				ORDER BY gp.pool",
         DBEscapeString($teamId),
         DBEscapeString($teamId),
         DBEscapeString($teamId),
@@ -309,10 +310,11 @@ function TeamSerieGames($teamId, $serieId)
 {
     $query = sprintf(
         "
-			SELECT pp.game_id, pp.hometeam, pp.visitorteam, pp.homescore, 
+			SELECT pp.game_id, pp.hometeam, pp.visitorteam, pp.homescore,
 			pp.visitorscore, pp.hasstarted, pp.time
-			FROM uo_game pp 
-			WHERE pp.pool='%s' AND pp.valid=true AND (pp.visitorteam='%s' OR pp.hometeam='%s') 
+			FROM uo_game pp
+			INNER JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
+			WHERE gp.pool='%s' AND pp.valid=true AND (pp.visitorteam='%s' OR pp.hometeam='%s')
 			ORDER BY pp.time ASC",
         DBEscapeString($serieId),
         DBEscapeString($teamId),
@@ -612,12 +614,13 @@ function TeamPlayedGames($name, $seriestype, $sorting, $curSeason = false)
     $query = sprintf(
         "SELECT pj1.name AS hometeamname, pj2.name AS visitorteamname, pp.homescore, pp.visitorscore, pp.hasstarted,
 	ser.season as season_id, ps.name, pp.game_id, ps.pool_id
-	FROM uo_game pp 
-	LEFT JOIN uo_pool ps ON (ps.pool_id=pp.pool)
+	FROM uo_game pp
+	INNER JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
+	LEFT JOIN uo_pool ps ON (ps.pool_id=gp.pool)
 	LEFT JOIN uo_series ser ON (ps.series=ser.series_id)
-	LEFT JOIN uo_team pj1 ON(pp.hometeam=pj1.team_id) 
+	LEFT JOIN uo_team pj1 ON(pp.hometeam=pj1.team_id)
 	LEFT JOIN uo_team pj2 ON (pp.visitorteam=pj2.team_id)
-	WHERE (pj1.name='%s' OR pj2.name='%s') AND ser.type='%s' 
+	WHERE (pj1.name='%s' OR pj2.name='%s') AND ser.type='%s'
 	AND pp.valid=true",
         DBEscapeString($name),
         DBEscapeString($name),
@@ -829,18 +832,19 @@ function TeamScoreBoard($teamId, $pools, $sorting, $limit)
 					LEFT JOIN uo_game_pool AS ps2 ON (m2.game=ps2.game) 
 					LEFT JOIN uo_game AS g3 ON (m2.game=g3.game_id) 
 						WHERE ps2.pool IN($poolList) AND g3.isongoing=0 GROUP BY assist) AS s ON (p.player_id=s.assist) 
-				LEFT JOIN uo_team AS j ON (p.team=j.team_id) 
+				LEFT JOIN uo_team AS j ON (p.team=j.team_id)
 				LEFT JOIN (SELECT player, COUNT(*) AS games FROM uo_played up
 					LEFT JOIN uo_game AS g4 ON (up.game=g4.game_id)
-						WHERE g4.pool IN($poolList) AND g4.isongoing=0 
+					INNER JOIN uo_game_pool gp4 ON (gp4.game=g4.game_id AND gp4.timetable=1)
+						WHERE gp4.pool IN($poolList) AND g4.isongoing=0
 						GROUP BY player) AS pel ON (p.player_id=pel.player) WHERE p.team=%d",
             (int) $teamId,
         );
     } else {
         $query = sprintf(
             "
-			SELECT p.player_id, p.firstname, p.lastname, j.name AS teamname, COALESCE(t.done,0) AS done, COALESCE(s.fedin,0) AS fedin, 
-				COALESCE(t1.callahan,0) AS callahan,(COALESCE(t.done,0) + COALESCE(s.fedin,0)) AS total, COALESCE(pel.games,0) AS games, 
+			SELECT p.player_id, p.firstname, p.lastname, j.name AS teamname, COALESCE(t.done,0) AS done, COALESCE(s.fedin,0) AS fedin,
+				COALESCE(t1.callahan,0) AS callahan,(COALESCE(t.done,0) + COALESCE(s.fedin,0)) AS total, COALESCE(pel.games,0) AS games,
         COALESCE(t.done/pel.games,0) AS doneavg, COALESCE(s.fedin/pel.games,0) AS fedinavg, COALESCE((COALESCE(t.done,0) + COALESCE(s.fedin,0))/pel.games,0) AS totalavg
 			FROM uo_player AS p 
 			LEFT JOIN (SELECT m.scorer AS scorer, COUNT(*) AS done FROM uo_goal AS m LEFT JOIN uo_game AS game ON (m.game=game.game_id) 
@@ -963,10 +967,11 @@ function TeamScoreBoardWithDefenses($teamId, $pools, $sorting, $limit)
 					LEFT JOIN uo_game_pool AS ps2 ON (m3.game=ps2.game) 
 					LEFT JOIN uo_game AS g3 ON (m3.game=g3.game_id) 
 					WHERE ps2.pool IN($poolList) AND g3.isongoing=0 GROUP BY author) AS d ON (p.player_id=d.author)
-				LEFT JOIN uo_team AS j ON (p.team=j.team_id) 
+				LEFT JOIN uo_team AS j ON (p.team=j.team_id)
 				LEFT JOIN (SELECT player, COUNT(*) AS games FROM uo_played up
 					LEFT JOIN uo_game AS g4 ON (up.game=g4.game_id)
-					WHERE g4.pool IN($poolList) AND g4.isongoing=0 
+					INNER JOIN uo_game_pool gp4 ON (gp4.game=g4.game_id AND gp4.timetable=1)
+					WHERE gp4.pool IN($poolList) AND g4.isongoing=0
 					GROUP BY player) AS pel ON (p.player_id=pel.player) WHERE p.team=%d",
             (int) $teamId,
         );
@@ -1066,11 +1071,12 @@ function GetAllPlayedGames($team1, $team2, $seriestype, $sorting)
 		SELECT pj1.name AS hometeamname, pj2.name AS visitorteamname, pp.homescore, pp.visitorscore,
   			pp.hasstarted, ser.season AS season_id, ps.name,
 			pp.game_id, ps.pool_id, s.name AS seasonname, pp.forfeit
-		FROM uo_game pp 
-		LEFT JOIN uo_pool ps ON (ps.pool_id=pp.pool) 
+		FROM uo_game pp
+		INNER JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
+		LEFT JOIN uo_pool ps ON (ps.pool_id=gp.pool)
 		LEFT JOIN uo_series ser ON (ps.series=ser.series_id)
 		LEFT JOIN uo_season s ON (s.season_id=ser.season)
-		LEFT JOIN uo_team pj1 ON(pp.hometeam=pj1.team_id) 
+		LEFT JOIN uo_team pj1 ON(pp.hometeam=pj1.team_id)
 		LEFT JOIN uo_team pj2 ON (pp.visitorteam=pj2.team_id)
 		WHERE ((REPLACE(pj1.name,' ','')='%s' AND REPLACE(pj2.name,' ','')='%s') OR (REPLACE(pj1.name,' ','')='%s' AND REPLACE(pj2.name,' ','')='%s'))
 			AND (pp.hasstarted > 0)

--- a/lib/timetable.functions.php
+++ b/lib/timetable.functions.php
@@ -655,7 +655,7 @@ function TimetableGames($id, $gamefilter, $timefilter, $order, $groupfilter = ""
 
     //common game query
     $query = "SELECT pp.game_id, pp.time, pp.hometeam, pp.visitorteam, pp.homescore,
-			pp.visitorscore, pp.pool AS pool, pool.name AS poolname, pool.timeslot,
+			pp.visitorscore, gp.pool AS pool, pool.name AS poolname, pool.timeslot,
 			ps.series_id, ps.name AS seriesname, ps.season, ps.type, pr.fieldname, pr.reservationgroup,
 			pr.id AS reservation_id, pr.starttime, pr.endtime, pl.id AS place_id, COALESCE(pm.goals,0) AS scoresheet,
 			pl.name AS placename, pl.address, pp.isongoing, pp.hasstarted, pp.islive, pp.forfeit, home.name AS hometeamname, visitor.name AS visitorteamname,
@@ -663,15 +663,16 @@ function TimetableGames($id, $gamefilter, $timefilter, $order, $groupfilter = ""
 			home.abbreviation AS homeshortname, visitor.abbreviation AS visitorshortname, homec.country_id AS homecountryid,
 			homec.name AS homecountry, visitorc.country_id AS visitorcountryid, visitorc.name AS visitorcountry,
 			homec.flagfile AS homeflag, visitorc.flagfile AS visitorflag, s.timezone
-			FROM uo_game pp 
+			FROM uo_game pp
+			INNER JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
 			LEFT JOIN (SELECT COUNT(*) AS goals, game FROM uo_goal GROUP BY game) AS pm ON (pp.game_id=pm.game)
-			LEFT JOIN uo_pool pool ON (pool.pool_id=pp.pool) 
+			LEFT JOIN uo_pool pool ON (pool.pool_id=gp.pool)
 			LEFT JOIN uo_series ps ON (pool.series=ps.series_id)
 			LEFT JOIN uo_season s ON (s.season_id=ps.season)
 			LEFT JOIN uo_reservation pr ON (pp.reservation=pr.id)
 			LEFT JOIN uo_location pl ON (pr.location=pl.id)
 			LEFT JOIN uo_team AS home ON (pp.hometeam=home.team_id)
-			LEFT JOIN uo_team_pool AS homepool ON (pp.hometeam=homepool.team AND pp.pool=homepool.pool)
+			LEFT JOIN uo_team_pool AS homepool ON (pp.hometeam=homepool.team AND gp.pool=homepool.pool)
 			LEFT JOIN uo_team AS visitor ON (pp.visitorteam=visitor.team_id)
 			LEFT JOIN uo_country AS homec ON (homec.country_id=home.country)
 			LEFT JOIN uo_country AS visitorc ON (visitorc.country_id=visitor.country)
@@ -689,14 +690,14 @@ function TimetableGames($id, $gamefilter, $timefilter, $order, $groupfilter = ""
             break;
 
         case "pool":
-            $query .= " WHERE pp.valid=true AND pp.pool='" . (int) $id . "'";
+            $query .= " WHERE pp.valid=true AND gp.pool='" . (int) $id . "'";
             break;
 
         case "poolgroup":
             //keep pool filter as it is to give better performance for single pool query
             //extra explode needed to make parameters safe
             $pools = explode(",", DBEscapeString($id));
-            $query .= " WHERE pp.valid=true AND pp.pool IN(" . implode(",", $pools) . ")";
+            $query .= " WHERE pp.valid=true AND gp.pool IN(" . implode(",", $pools) . ")";
             break;
 
         case "team":
@@ -807,9 +808,10 @@ function TimetableGrouping($id, $gamefilter, $timefilter)
 {
     //common game query
     $query = "SELECT pr.reservationgroup, MAX(pp.time)
-			FROM uo_game pp 
+			FROM uo_game pp
+			INNER JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
 			LEFT JOIN (SELECT COUNT(*) AS goals, game FROM uo_goal GROUP BY game) AS pm ON (pp.game_id=pm.game)
-			LEFT JOIN uo_pool pool ON (pool.pool_id=pp.pool) 
+			LEFT JOIN uo_pool pool ON (pool.pool_id=gp.pool)
 			LEFT JOIN uo_series ps ON (pool.series=ps.series_id)
 			LEFT JOIN uo_reservation pr ON (pp.reservation=pr.id)
 			LEFT JOIN uo_location pl ON (pr.location=pl.id)
@@ -828,14 +830,14 @@ function TimetableGrouping($id, $gamefilter, $timefilter)
             break;
 
         case "pool":
-            $query .= " WHERE pp.valid=true AND pp.pool='" . (int) $id . "'";
+            $query .= " WHERE pp.valid=true AND gp.pool='" . (int) $id . "'";
             break;
 
         case "poolgroup":
             //keep pool filter as it is to give better performance for single pool query
             //extra explode needed to make parameters safe
             $pools = explode(",", DBEscapeString($id));
-            $query .= " WHERE pp.valid=true AND pp.pool IN(" . implode(",", $pools) . ")";
+            $query .= " WHERE pp.valid=true AND gp.pool IN(" . implode(",", $pools) . ")";
             break;
 
         case "team":
@@ -896,9 +898,10 @@ function TimetableGrouping($id, $gamefilter, $timefilter)
 function TimetableFields($reservationgroup, $season)
 {
     $query = "SELECT COUNT(*) as games
-			FROM uo_game pp 
+			FROM uo_game pp
+			INNER JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
 			LEFT JOIN (SELECT COUNT(*) AS goals, game FROM uo_goal GROUP BY game) AS pm ON (pp.game_id=pm.game)
-			LEFT JOIN uo_pool pool ON (pool.pool_id=pp.pool) 
+			LEFT JOIN uo_pool pool ON (pool.pool_id=gp.pool)
 			LEFT JOIN uo_series ps ON (pool.series=ps.series_id)
 			LEFT JOIN uo_reservation pr ON (pp.reservation=pr.id)";
 
@@ -911,8 +914,9 @@ function TimetableFields($reservationgroup, $season)
 function TimetableTimeslots($reservationgroup, $season)
 {
     $query = "SELECT pp.time
-			FROM uo_game pp 
-			LEFT JOIN uo_pool pool ON (pool.pool_id=pp.pool) 
+			FROM uo_game pp
+			INNER JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
+			LEFT JOIN uo_pool pool ON (pool.pool_id=gp.pool)
 			LEFT JOIN uo_series ps ON (pool.series=ps.series_id)
 			LEFT JOIN uo_reservation pr ON (pp.reservation=pr.id)";
 
@@ -923,17 +927,19 @@ function TimetableTimeslots($reservationgroup, $season)
 
 function TimetableIntraPoolConflicts($season)
 {
-    $query = "SELECT g1.game_id as game1, g2.game_id as game2, g1.pool as pool1, g2.pool as pool2,  
-      g1.hometeam as home1, g1.visitorteam as visitor1, g2.hometeam as home2, g2.visitorteam as visitor2, 
-      g1.scheduling_name_home as scheduling_home1, g1.scheduling_name_visitor as scheduling_visitor1, 
-      g2.scheduling_name_home as scheduling_home2, g2.scheduling_name_visitor as scheduling_visitor2, 
-      g1.reservation as reservation1, g2.reservation as reservation2, g1.time as time1, g2.time as time2, 
-      p1.timeslot as slot1, p2.timeslot as slot2, 
-      res1.location location1, res1.fieldname as field1, res2.location as location2, res2.fieldname as field2  
+    $query = "SELECT g1.game_id as game1, g2.game_id as game2, gp1.pool as pool1, gp2.pool as pool2,
+      g1.hometeam as home1, g1.visitorteam as visitor1, g2.hometeam as home2, g2.visitorteam as visitor2,
+      g1.scheduling_name_home as scheduling_home1, g1.scheduling_name_visitor as scheduling_visitor1,
+      g2.scheduling_name_home as scheduling_home2, g2.scheduling_name_visitor as scheduling_visitor2,
+      g1.reservation as reservation1, g2.reservation as reservation2, g1.time as time1, g2.time as time2,
+      p1.timeslot as slot1, p2.timeslot as slot2,
+      res1.location location1, res1.fieldname as field1, res2.location as location2, res2.fieldname as field2
       FROM uo_game as g1
+      INNER JOIN uo_game_pool gp1 ON (gp1.game = g1.game_id AND gp1.timetable = 1)
       LEFT JOIN uo_game as g2 ON ((g1.hometeam=g2.hometeam OR g1.visitorteam = g2.visitorteam OR g1.hometeam=g2.visitorteam OR g1.visitorteam = g2.hometeam) AND g1.game_id != g2.game_id )
-      LEFT JOIN uo_pool as p1 ON (p1.pool_id = g1.pool)
-      LEFT JOIN uo_pool as p2 ON (p2.pool_id = g2.pool)
+      LEFT JOIN uo_game_pool gp2 ON (gp2.game = g2.game_id AND gp2.timetable = 1)
+      LEFT JOIN uo_pool as p1 ON (p1.pool_id = gp1.pool)
+      LEFT JOIN uo_pool as p2 ON (p2.pool_id = gp2.pool)
       LEFT JOIN uo_reservation as res1 ON (res1.id = g1.reservation)
       LEFT JOIN uo_reservation as res2 ON (res2.id = g2.reservation)
       LEFT JOIN uo_series as ser1 ON (ser1.series_id = p1.series)
@@ -945,18 +951,20 @@ function TimetableIntraPoolConflicts($season)
 
 function TimetableInterPoolConflicts($season)
 {
-    $query = "SELECT  g1.game_id as game1, g2.game_id as game2, g1.pool as pool1, g2.pool as pool2,  
-      g1.hometeam as home1, g1.visitorteam as visitor1, g2.hometeam as home2, g2.visitorteam as visitor2, 
-      g1.scheduling_name_home as scheduling_home1, g1.scheduling_name_visitor as scheduling_visitor1, 
-      g2.scheduling_name_home as scheduling_home2, g2.scheduling_name_visitor as scheduling_visitor2, 
-      g1.reservation as reservation1, g2.reservation as reservation2, g1.time as time1, g2.time as time2, 
-      p1.timeslot as slot1, p2.timeslot as slot2, 
+    $query = "SELECT  g1.game_id as game1, g2.game_id as game2, gp1.pool as pool1, gp2.pool as pool2,
+      g1.hometeam as home1, g1.visitorteam as visitor1, g2.hometeam as home2, g2.visitorteam as visitor2,
+      g1.scheduling_name_home as scheduling_home1, g1.scheduling_name_visitor as scheduling_visitor1,
+      g2.scheduling_name_home as scheduling_home2, g2.scheduling_name_visitor as scheduling_visitor2,
+      g1.reservation as reservation1, g2.reservation as reservation2, g1.time as time1, g2.time as time2,
+      p1.timeslot as slot1, p2.timeslot as slot2,
       res1.location location1, res1.fieldname as field1, res2.location as location2, res2.fieldname as field2
       FROM uo_moveteams as mv
-      LEFT JOIN uo_game as g1 ON (g1.pool = mv.frompool)
-      LEFT JOIN uo_game as g2 ON (g2.pool = mv.topool AND g1.game_id != g2.game_id )
-      LEFT JOIN uo_pool as p1 ON (p1.pool_id = g1.pool)
-      LEFT JOIN uo_pool as p2 ON (p2.pool_id = g2.pool)
+      LEFT JOIN uo_game_pool as gp1 ON (gp1.pool = mv.frompool AND gp1.timetable = 1)
+      LEFT JOIN uo_game as g1 ON (g1.game_id = gp1.game)
+      LEFT JOIN uo_game_pool as gp2 ON (gp2.pool = mv.topool AND gp2.timetable = 1 AND gp1.game != gp2.game)
+      LEFT JOIN uo_game as g2 ON (g2.game_id = gp2.game)
+      LEFT JOIN uo_pool as p1 ON (p1.pool_id = gp1.pool)
+      LEFT JOIN uo_pool as p2 ON (p2.pool_id = gp2.pool)
       LEFT JOIN uo_reservation as res1 ON (res1.id = g1.reservation)
       LEFT JOIN uo_reservation as res2 ON (res2.id = g2.reservation)
       LEFT JOIN uo_series as ser1 ON (ser1.series_id = p1.series)
@@ -1038,9 +1046,10 @@ function TimetableToCsv($season, $separator)
 			pp.visitorscore AS VisitorScores, pool.name AS Pool, ps.name AS Division, 
 			pr.fieldname AS Field, pr.reservationgroup AS ReservationGroup,
 			pl.name AS Place, pp.name AS GameName
-			FROM uo_game pp 
+			FROM uo_game pp
+			INNER JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
 			LEFT JOIN (SELECT COUNT(*) AS goals, game FROM uo_goal GROUP BY game) AS pm ON (pp.game_id=pm.game)
-			LEFT JOIN uo_pool pool ON (pool.pool_id=pp.pool) 
+			LEFT JOIN uo_pool pool ON (pool.pool_id=gp.pool)
 			LEFT JOIN uo_series ps ON (pool.series=ps.series_id)
 			LEFT JOIN uo_reservation pr ON (pp.reservation=pr.id)
 			LEFT JOIN uo_location pl ON (pr.location=pl.id)

--- a/lib/user.functions.php
+++ b/lib/user.functions.php
@@ -1677,15 +1677,17 @@ function GameResponsibilityArray($season, $series = null)
         return [];
     }
     $query = sprintf(
-        "SELECT game_id, hometeam, kj.name as hometeamname, visitorteam,
-			vj.name as visitorteamname, pp.pool as pool, time, homescore, visitorscore,
+        "SELECT pp.game_id, hometeam, kj.name as hometeamname, visitorteam,
+			vj.name as visitorteamname, gp.pool as pool, time, homescore, visitorscore,
 			pool.timecap, pool.timeslot, pool.series, res.reservationgroup,
 			ser.name, pool.name as poolname, res.id as res_id, res.starttime,
 			loc.name AS locationname, res.fieldname AS fieldname, res.location,
 			COALESCE(m.goals,0) AS goals, phome.name AS phometeamname, pvisitor.name AS pvisitorteamname,
 	        pp.isongoing, pp.hasstarted
-		FROM uo_game pp left join uo_reservation res on (pp.reservation=res.id) 
-			left join uo_pool pool on (pp.pool=pool.pool_id)
+		FROM uo_game pp
+			INNER JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
+			left join uo_reservation res on (pp.reservation=res.id)
+			left join uo_pool pool on (pool.pool_id=gp.pool)
 			left join uo_series ser on (pool.series=ser.series_id)
 			left join uo_location loc on (res.location=loc.id)
 			left join uo_team kj on (pp.hometeam=kj.team_id)
@@ -1693,7 +1695,7 @@ function GameResponsibilityArray($season, $series = null)
 			LEFT JOIN uo_scheduling_name AS phome ON (pp.scheduling_name_home=phome.scheduling_id)
 			LEFT JOIN uo_scheduling_name AS pvisitor ON (pp.scheduling_name_visitor=pvisitor.scheduling_id)
 			left join (SELECT COUNT(*) AS goals, game FROM uo_goal GROUP BY game) AS m ON (pp.game_id=m.game)
-		WHERE game_id IN (" . implode(",", array_column($gameResponsibilities, 'game_id')) . ")"
+		WHERE pp.game_id IN (" . implode(",", array_column($gameResponsibilities, 'game_id')) . ")"
             . ($series ? " AND pool.series=%d" : "") . "
 		ORDER BY res.starttime ASC, res.reservationgroup ASC, res.fieldname+0,pp.time ASC",
         $series ? (int) $series : 0,

--- a/sql/ultiorganizer.sql
+++ b/sql/ultiorganizer.sql
@@ -409,7 +409,6 @@ CREATE TABLE IF NOT EXISTS `uo_game` (
   `visitorscore` smallint(5) DEFAULT NULL,
   `reservation` int(10) DEFAULT NULL,
   `time` datetime DEFAULT NULL,
-  `pool` int(10) DEFAULT NULL,
   `valid` tinyint(1) NOT NULL,
   `halftime` int(10) DEFAULT NULL,
   `official` varchar(50) DEFAULT NULL,
@@ -436,13 +435,10 @@ CREATE TABLE IF NOT EXISTS `uo_game` (
   KEY `idx_reservation` (`reservation`),
   KEY `idx_game_id` (`game_id`),
   KEY `idx_name` (`name`),
-  KEY `idx_pool` (`pool`),
   KEY `idx_game_valid_time` (`valid`,`time`),
-  KEY `idx_game_valid_pool_time` (`valid`,`pool`,`time`),
   KEY `idx_game_valid_hometeam_time` (`valid`,`hometeam`,`time`),
   KEY `idx_game_valid_visitorteam_time` (`valid`,`visitorteam`,`time`),
   CONSTRAINT `fk_game_hometeam` FOREIGN KEY (`hometeam`) REFERENCES `uo_team` (`team_id`) ON DELETE SET NULL ON UPDATE CASCADE,
-  CONSTRAINT `fk_game_pool` FOREIGN KEY (`pool`) REFERENCES `uo_pool` (`pool_id`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `fk_game_reservation` FOREIGN KEY (`reservation`) REFERENCES `uo_reservation` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `fk_game_visitorteam` FOREIGN KEY (`visitorteam`) REFERENCES `uo_team` (`team_id`) ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB AUTO_INCREMENT=1000 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/sql/upgrade_db.php
+++ b/sql/upgrade_db.php
@@ -1217,6 +1217,121 @@ function upgrade91()
     }
 }
 
+/**
+ * Drop uo_game.pool in favor of uo_game_pool as the single source of truth.
+ *
+ * Backfills any missing timetable=1 rows from the legacy column, then removes
+ * the column, its indexes, and the foreign key. Pre-existing divergence
+ * (uo_game.pool changed without a matching uo_game_pool update) is patched
+ * silently; the operator can inspect server error log for the counts.
+ */
+function upgrade92()
+{
+    if (!hasColumn('uo_game', 'pool')) {
+        return;
+    }
+
+    $missingOwner = DBQueryToValue(
+        "SELECT COUNT(*) FROM uo_game g
+            LEFT JOIN uo_game_pool gp ON (gp.game = g.game_id AND gp.timetable = 1)
+            WHERE g.pool IS NOT NULL AND gp.game IS NULL",
+    );
+    $divergent = DBQueryToValue(
+        "SELECT COUNT(*) FROM uo_game g
+            INNER JOIN uo_game_pool gp ON (gp.game = g.game_id AND gp.timetable = 1)
+            WHERE g.pool IS NOT NULL AND gp.pool != g.pool",
+    );
+    $orphans = DBQueryToValue(
+        "SELECT COUNT(*) FROM uo_game g
+            LEFT JOIN uo_game_pool gp ON (gp.game = g.game_id AND gp.timetable = 1)
+            WHERE g.pool IS NULL AND gp.game IS NULL",
+    );
+    $duplicateOwners = DBQueryToValue(
+        "SELECT COUNT(*) FROM (
+            SELECT game FROM uo_game_pool WHERE timetable = 1 GROUP BY game HAVING COUNT(*) > 1
+        ) t",
+    );
+    error_log(sprintf(
+        "upgrade92: backfilling uo_game_pool from uo_game.pool: missing_owner=%d divergent=%d orphans=%d duplicate_owners=%d",
+        (int) $missingOwner,
+        (int) $divergent,
+        (int) $orphans,
+        (int) $duplicateOwners,
+    ));
+
+    // Dedup timetable=1 rows first: keep the row whose pool matches uo_game.pool
+    // if any, else the lowest pool_id, so the divergent UPDATE below cannot hit
+    // a PK collision and the application's "exactly one owner row per game"
+    // invariant is enforced before we drop the column.
+    runQuery(
+        "DELETE gp FROM uo_game_pool gp
+            LEFT JOIN uo_game g ON g.game_id = gp.game
+            INNER JOIN (
+                SELECT game,
+                    MIN(CASE WHEN g2.pool = gp2.pool THEN gp2.pool END) AS preferred_pool,
+                    MIN(gp2.pool) AS fallback_pool
+                FROM uo_game_pool gp2
+                INNER JOIN uo_game g2 ON g2.game_id = gp2.game
+                WHERE gp2.timetable = 1
+                GROUP BY game
+                HAVING COUNT(*) > 1
+            ) dups ON dups.game = gp.game
+            WHERE gp.timetable = 1
+              AND gp.pool != COALESCE(dups.preferred_pool, dups.fallback_pool)",
+    );
+
+    // Realign owner rows so uo_game.pool wins (it captures the most recent
+    // SetGame() intent, which historically only updated the column). Use a
+    // delete + insert pattern rather than UPDATE so we never collide on the
+    // (game, pool) primary key when a carryover row already exists at the
+    // target pool.
+
+    // 1. Drop divergent owner rows.
+    runQuery(
+        "DELETE gp FROM uo_game_pool gp
+            INNER JOIN uo_game g ON g.game_id = gp.game
+            WHERE gp.timetable = 1 AND g.pool IS NOT NULL AND gp.pool != g.pool",
+    );
+    // 2. Drop any carryover row sitting at the target pool; it would conflict
+    //    with the owner row we're about to insert and is semantically redundant
+    //    (a game cannot be both owner and carryover in the same pool).
+    runQuery(
+        "DELETE gp FROM uo_game_pool gp
+            INNER JOIN uo_game g ON g.game_id = gp.game
+            WHERE gp.timetable = 0 AND g.pool IS NOT NULL AND gp.pool = g.pool",
+    );
+    // 3. Insert the owner row. INSERT IGNORE makes step 3 a no-op when an
+    //    already-matching owner row survived from step 1.
+    runQuery(
+        "INSERT IGNORE INTO uo_game_pool (game, pool, timetable)
+            SELECT game_id, pool, 1 FROM uo_game WHERE pool IS NOT NULL",
+    );
+
+    // Drop any foreign key that references uo_game.pool, regardless of constraint name.
+    // Older installs (pre-InnoDB conversion) use auto-generated names like uo_game_FK_3;
+    // newer installs use the canonical fk_game_pool.
+    $fkResult = runQuery(sprintf(
+        "SELECT CONSTRAINT_NAME FROM information_schema.KEY_COLUMN_USAGE
+            WHERE CONSTRAINT_SCHEMA = '%s' AND TABLE_NAME = 'uo_game' AND COLUMN_NAME = 'pool'
+            AND REFERENCED_TABLE_NAME IS NOT NULL",
+        DBEscapeString(DB_DATABASE),
+    ));
+    if ($fkResult) {
+        while ($row = mysqli_fetch_assoc($fkResult)) {
+            dropForeignKey('uo_game', $row['CONSTRAINT_NAME']);
+        }
+    }
+
+    if (hasIndex('uo_game', 'idx_pool')) {
+        runQuery("ALTER TABLE `uo_game` DROP INDEX `idx_pool`");
+    }
+    if (hasIndex('uo_game', 'idx_game_valid_pool_time')) {
+        runQuery("ALTER TABLE `uo_game` DROP INDEX `idx_game_valid_pool_time`");
+    }
+
+    runQuery("ALTER TABLE `uo_game` DROP COLUMN `pool`");
+}
+
 function upgradeEngineToInnoDb()
 {
     $charset = 'utf8mb4';
@@ -1494,7 +1609,6 @@ function cleanupNullableOrphans()
         "UPDATE uo_player p LEFT JOIN uo_player_profile pr ON pr.profile_id = p.profile_id SET p.profile_id = NULL WHERE p.profile_id IS NOT NULL AND (p.profile_id = 0 OR pr.profile_id IS NULL)",
         "UPDATE uo_game g LEFT JOIN uo_team t ON t.team_id = g.hometeam SET g.hometeam = NULL WHERE g.hometeam IS NOT NULL AND (g.hometeam = 0 OR t.team_id IS NULL)",
         "UPDATE uo_game g LEFT JOIN uo_team t ON t.team_id = g.visitorteam SET g.visitorteam = NULL WHERE g.visitorteam IS NOT NULL AND (g.visitorteam = 0 OR t.team_id IS NULL)",
-        "UPDATE uo_game g LEFT JOIN uo_pool p ON p.pool_id = g.pool SET g.pool = NULL WHERE g.pool IS NOT NULL AND (g.pool = 0 OR p.pool_id IS NULL)",
         "UPDATE uo_game g LEFT JOIN uo_reservation r ON r.id = g.reservation SET g.reservation = NULL WHERE g.reservation IS NOT NULL AND (g.reservation = 0 OR r.id IS NULL)",
         "UPDATE uo_reservation r LEFT JOIN uo_location l ON l.id = r.location SET r.location = NULL WHERE r.location IS NOT NULL AND (r.location = 0 OR l.id IS NULL)",
         "UPDATE uo_goal go LEFT JOIN uo_player p ON p.player_id = go.assist SET go.assist = NULL WHERE go.assist IS NOT NULL AND (go.assist = 0 OR p.player_id IS NULL)",
@@ -1529,7 +1643,6 @@ function findOrphanErrors()
         "uo_player_stats.series" => "SELECT 1 FROM uo_player_stats ps LEFT JOIN uo_series s ON s.series_id = ps.series WHERE ps.series IS NOT NULL AND s.series_id IS NULL LIMIT 1",
         "uo_player_stats.season" => "SELECT 1 FROM uo_player_stats ps LEFT JOIN uo_season se ON se.season_id = ps.season WHERE ps.season IS NOT NULL AND se.season_id IS NULL LIMIT 1",
         "uo_game.hometeam/visitorteam" => "SELECT 1 FROM uo_game g LEFT JOIN uo_team t1 ON t1.team_id = g.hometeam LEFT JOIN uo_team t2 ON t2.team_id = g.visitorteam WHERE (g.hometeam IS NOT NULL AND t1.team_id IS NULL) OR (g.visitorteam IS NOT NULL AND t2.team_id IS NULL) LIMIT 1",
-        "uo_game.pool" => "SELECT 1 FROM uo_game g LEFT JOIN uo_pool p ON p.pool_id = g.pool WHERE g.pool IS NOT NULL AND p.pool_id IS NULL LIMIT 1",
         "uo_game.reservation" => "SELECT 1 FROM uo_game g LEFT JOIN uo_reservation r ON r.id = g.reservation WHERE g.reservation IS NOT NULL AND r.id IS NULL LIMIT 1",
         "uo_goal.game" => "SELECT 1 FROM uo_goal go LEFT JOIN uo_game g ON g.game_id = go.game WHERE go.game IS NOT NULL AND g.game_id IS NULL LIMIT 1",
         "uo_goal.assist/scorer" => "SELECT 1 FROM uo_goal go LEFT JOIN uo_player p1 ON p1.player_id = go.assist LEFT JOIN uo_player p2 ON p2.player_id = go.scorer WHERE (go.assist IS NOT NULL AND p1.player_id IS NULL) OR (go.scorer IS NOT NULL AND p2.player_id IS NULL) LIMIT 1",
@@ -1595,7 +1708,6 @@ function addInnoDbForeignKeys()
     addForeignKey('uo_game', 'fk_game_hometeam', "FOREIGN KEY (`hometeam`) REFERENCES `uo_team` (`team_id`) ON DELETE SET NULL ON UPDATE CASCADE");
     addForeignKey('uo_game', 'fk_game_visitorteam', "FOREIGN KEY (`visitorteam`) REFERENCES `uo_team` (`team_id`) ON DELETE SET NULL ON UPDATE CASCADE");
     addForeignKey('uo_game', 'fk_game_reservation', "FOREIGN KEY (`reservation`) REFERENCES `uo_reservation` (`id`) ON DELETE SET NULL ON UPDATE CASCADE");
-    addForeignKey('uo_game', 'fk_game_pool', "FOREIGN KEY (`pool`) REFERENCES `uo_pool` (`pool_id`) ON DELETE SET NULL ON UPDATE CASCADE");
 
     addForeignKey('uo_goal', 'fk_goal_game', "FOREIGN KEY (`game`) REFERENCES `uo_game` (`game_id`) ON DELETE CASCADE ON UPDATE CASCADE");
     addForeignKey('uo_goal', 'fk_goal_assist', "FOREIGN KEY (`assist`) REFERENCES `uo_player` (`player_id`) ON DELETE SET NULL ON UPDATE CASCADE");


### PR DESCRIPTION
## Summary

- `uo_game.pool` and `uo_game_pool` both encoded the game-to-pool relationship, and `SetGame()` updated only the column — the two could silently diverge. Drop `uo_game.pool` entirely and use `uo_game_pool` as the only source of truth: `timetable=1` is the owning/scheduled pool, `timetable=0` is carryover into continuation pools.
- New `SetGamePool($gameId, $poolId)` helper enforces the "exactly one owner row per game" invariant for `SetGame()`, `AddGame()`, and both XML import paths. It deletes any stale owner row, promotes a matching carryover row, and inserts via `ON DUPLICATE KEY UPDATE`.
- `upgrade92()` runs in this order so the migration cannot collide on `(game, pool)`: dedup duplicate `timetable=1` rows → delete divergent owner rows → delete any carryover row sitting at the would-be owner's pool → `INSERT IGNORE` the owner row from `uo_game.pool` → drop the FK / indexes / column. Pre-flight counts (`missing_owner`, `divergent`, `orphans`, `duplicate_owners`) go to `error_log` so the operator sees how much drift was repaired.
- 13 lib files rewritten so every `g.pool` / `pp.pool` / `uo_game.pool` read joins through `uo_game_pool` with `timetable=1` (owner-pool pattern) or without (any-associated-pool pattern), per the catalogue documented in the commit. All four `INSERT INTO uo_game` write sites drop the `pool` column. `PoolDeleteAllGames` reordered to use the `timetable=1` join. `CheckBYE` UPDATEs join through `uo_game_pool`.
- XML export drives the per-pool game loop from `uo_game_pool` (`timetable=1`). XML import captures the legacy `<POOL>` cell on `<uo_game>` and, after the parse loop, replays it through `SetGamePool()` only when no explicit owner row was provided by the file. Both `<uo_game_pool>` import paths route owner rows through `SetGamePool()`.
- `sql/ultiorganizer.sql`, `cleanupNullableOrphans`, `findOrphanErrors`, `addInnoDbForeignKeys` all updated to drop the column references. `docs/schedule.md` describes the new single-source-of-truth semantics.

## Test plan

- [x] `composer check` baseline unchanged at 444 (PHPStan + PHP-CS-Fixer)
- [x] `composer format:check` clean
- [x] `php docs/ai/review-database-access/scripts/check-db-access.php --changed` blocking=0
- [x] `git diff --check` clean
- [x] Migration verified against a worst-case synthetic dataset (game with divergent owner + carryover-at-target; game with two duplicate owners) — both cleaned to exactly one owner row matching `uo_game.pool`, column dropped
- [x] `SetGamePool()` upsert verified for: set-to-same, move-to-different, upsert-into-orphan, promote-carryover
- [x] Auto-move on game completion verified end-to-end for both `ResolveSeriesPoolStandings` (round-robin → `PoolMakeMove` for `mvgames=1` followers) and `ResolvePlayoffPoolStandings` (playoff → `TeamMove`) paths
- [x] `PoolConfirmMoves` (admin pool-completion) verified: clearing the 4 existing carryover rows in pool 14 and re-running rebuilt them with owner pools intact in pools 12/13
- [x] Live smoke test of ~20 public/admin views (games, poolstatus, scorestatus, seriesstatus, spiritstatus, teamcard, playercard, statistics, playerlist, ical, ...): all 200 OK, zero `Fatal/SQL syntax/Unknown column` errors in HTML or apache logs
- [ ] Companion harness fix landed separately in `ktolonen/ultiorganizer-tests` (commit `7436caf` on `feature-lib-unit-tests`): drops `pool` from the baseline fixture's `INSERT INTO uo_game` and switches the harness from `mariadb -e "source path"` to piping via stdin so SQL load errors actually fail the run instead of being silently swallowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)