### PR TITLE
[codex] Fix release build portability

### DIFF
--- a/docs/release/build-release.sh
+++ b/docs/release/build-release.sh
@@ -100,7 +100,7 @@ fi
 
 APP_VERSION="$(
     php -r '$version = include "version.php"; if (!is_string($version) || trim($version) === "") { exit(1); } echo trim($version);' 2>/dev/null \
-        || sed -n "s/^[[:space:]]*\\(<?php[[:space:]]*\\)\\?return[[:space:]]*['\"]\\([^'\"]\\+\\)['\"][[:space:]]*;[[:space:]]*$/\\2/p" version.php | head -n 1
+        || sed -n "s/^[[:space:]]*return[[:space:]]*['\"]\\([^'\"]\\+\\)['\"][[:space:]]*;[[:space:]]*$/\\1/p" version.php | head -n 1
 )"
 
 if [[ -z "${APP_VERSION}" ]]; then
@@ -207,6 +207,9 @@ trap 'rm -rf "${WORK_DIR}"' EXIT
 PACKAGE_DIR="${WORK_DIR}/${PACKAGE_NAME}"
 mkdir -p "${PACKAGE_DIR}" "${DIST_DIR}"
 
+TRACKED_FILES_LIST="${WORK_DIR}/tracked-files.zlist"
+git ls-files -z > "${TRACKED_FILES_LIST}"
+
 while IFS= read -r -d '' path; do
     if [[ -d "${path}" ]]; then
         continue
@@ -223,7 +226,7 @@ while IFS= read -r -d '' path; do
 
     mkdir -p "${PACKAGE_DIR}/$(dirname "${path}")"
     cp -p "${path}" "${PACKAGE_DIR}/${path}"
-done < <(git ls-files -z)
+done < "${TRACKED_FILES_LIST}"
 
 required_paths=(
     "README.md"
@@ -316,13 +319,16 @@ if [[ "${PACKAGE_TYPE}" == "update" ]]; then
 fi
 
 if [[ "${ALL_CUSTOMIZATIONS}" -eq 0 ]]; then
+    CUSTOMIZATION_DIRS_LIST="${WORK_DIR}/customization-dirs.list"
+    find "${PACKAGE_DIR}/cust" -mindepth 1 -maxdepth 1 -type d > "${CUSTOMIZATION_DIRS_LIST}"
+
     while IFS= read -r customization_path; do
         customization="$(basename "${customization_path}")"
         if [[ "${customization}" != "default" ]] && ! contains_customization "${customization}"; then
             echo "error: package contains unselected customization: cust/${customization}" >&2
             exit 1
         fi
-    done < <(find "${PACKAGE_DIR}/cust" -mindepth 1 -maxdepth 1 -type d)
+    done < "${CUSTOMIZATION_DIRS_LIST}"
 fi
 
 rm -f "${ARCHIVE_PATH}"


### PR DESCRIPTION
## Summary

- Fix the `version.php` fallback parser so release builds can read the current multi-line `return '4.0';` file shape when PHP is missing or unavailable.
- Replace Bash process substitution in the release copy and customization validation loops with temporary list files.

## Root Cause

`docs/release/build-release.sh` had two portability assumptions: the sed fallback only matched a one-line PHP return statement, and the file-copy loop used `/dev/fd`-backed process substitution. On hosts without usable PHP or `/dev/fd`, the release build could fail before staging files, then report missing required paths such as `README.md`.

## Validation

- `bash -n docs/release/build-release.sh`
- `docs/release/build-release.sh`
- direct sed fallback check against `version.php` returned `4.0`