### PR TITLE
[codex] Update Live game pool compatibility patch

### DIFF
--- a/live/ultiorganizer-compat.patch
+++ b/live/ultiorganizer-compat.patch
@@ -60,6 +60,28 @@
                      'name' => $season['name']
 --- a/api/GameManager.php
 +++ b/api/GameManager.php
+@@ -43,7 +43,8 @@
+ 		// First, let's the the game IDs that we're looking for
+ 		$query = sprintf(
+ 			"SELECT game_id FROM uo_game game
+-			JOIN uo_pool pool ON pool.pool_id = game.pool
++			JOIN uo_game_pool gp ON gp.game = game.game_id AND gp.timetable = 1
++			JOIN uo_pool pool ON pool.pool_id = gp.pool
+ 			JOIN uo_series ser ON ser.series_id = pool.series
+ 			WHERE ser.season = '%s' " . ($activeGameWindow ? "AND ( ( game.time >= '%s' AND game.time <= '%s' ) OR game.isongoing = 1 )" : '') . " ORDER BY game.game_id",
+ 			$seasonId,
+@@ -63,9 +64,10 @@
+ 
+ 		// Get the data for the games
+ 		$query = sprintf(
+-			"SELECT game.*, gameschedulingname.name AS gameschedulingname, homeschedulingname.name AS homeschedulingname,
++			"SELECT game.*, gp.pool AS pool, gameschedulingname.name AS gameschedulingname, homeschedulingname.name AS homeschedulingname,
+ 									visitorschedulingname.name AS visitorschedulingname, setgamename.name AS gamename
+              FROM uo_game game
++             JOIN uo_game_pool gp ON gp.game = game.game_id AND gp.timetable = 1
+              LEFT JOIN uo_scheduling_name gameschedulingname ON game.name = gameschedulingname.scheduling_id
+              LEFT JOIN uo_scheduling_name homeschedulingname ON game.scheduling_name_home = homeschedulingname.scheduling_id
+              LEFT JOIN uo_scheduling_name visitorschedulingname ON game.scheduling_name_visitor = visitorschedulingname.scheduling_id
 @@ -205,14 +205,14 @@
  			'seasoninfo'             => $seasonInfo,
  

--- a/live/ultiorganizer-patch.md
+++ b/live/ultiorganizer-patch.md
@@ -39,6 +39,10 @@ versions), so the Live! skin works across both.
 
 ### `api/GameManager.php`
 
+- `getGames()`: replaced the legacy `uo_game.pool` join with
+  `uo_game_pool` using `timetable = 1`, which is the scheduled/original pool
+  that `uo_game.pool` used to represent. The game list query still exposes
+  this value as `pool` for the live frontend.
 - `getGameDetail()`: replaced `mysqli_fetch_all(GameTeamScoreBorad(...), MYSQLI_ASSOC)`
   with `DBFetchAllAssoc(GameTeamScoreBorad(...))` for both home and visitor scoreboards.
 - `getGameDetail()`: replaced `mysqli_fetch_all(GameGoals(...), MYSQLI_ASSOC)` with


### PR DESCRIPTION
## Summary

Updates the Live! by BULA compatibility patch so its game list query no longer depends on the removed `uo_game.pool` column.

The patch now joins `uo_game_pool` with `timetable = 1`, which represents the scheduled/original pool that Live previously read from `uo_game.pool`, and continues exposing that value as `pool` for the Live frontend.

## Root Cause

Ultiorganizer made `uo_game_pool` the source of truth for game-to-pool membership. Live's compatibility patch still had one `getGames()` query that joined pools through the legacy `uo_game.pool` column, causing Live's reference-data/SEO bootstrap to fail with `Unknown column 'game.pool'` and then surface as the `$seoManager` fatal in `live/index.php`.

## Validation

- `patch -p1 -R --dry-run < ultiorganizer-compat.patch` from `live/`
- `php -l live/api/GameManager.php`
- Docker PHP syntax check for `live/api/GameManager.php`
- `/?view=live/index` returns the Live page without the `$seoManager` fatal
- `/?view=live/api&entity=games` returns JSON with `pool`
- `/?view=live/api&entity=reference` returns JSON cleanly