### PR TITLE
Bug fixes: PDF font crash, scoresheet numeric keyboard

### DIFF
--- a/docs/codebase-notes.md
+++ b/docs/codebase-notes.md
@@ -13,6 +13,7 @@ This page collects implementation details that are useful during coding work but
 - Register Unicode fonts with `AddFont(..., true)`. DejaVu TTFs are under `lib/tfpdf/font/unifont/`.
 - Keep PDF text in UTF-8. Do not use `utf8_decode` or ISO-8859 transcoding helpers.
 - After registering DejaVu under family `Arial`, continue using `SetFont('Arial', ...)`.
+- Local tFPDF modification: the Unicode-font metrics cache (`*.mtx.php`, `*.cw.dat`, `*.cw127.php` under `lib/tfpdf/font/unifont/`) is disabled in `tfpdf.php` (`AddFont()` and `_putTTfontwidths()`). The upstream cache stored the font's absolute path, which broke PDF generation when the app was deployed to a different directory than where the cache was generated. Metrics are now regenerated in memory on each run (negligible cost; PDFs are rare) and no writable font directory is required. Re-apply this change after any tFPDF upgrade; the modified sections are marked with `Ultiorganizer local modification` comments.
 
 ## Plugins
 

--- a/lib/tfpdf/tfpdf.php
+++ b/lib/tfpdf/tfpdf.php
@@ -486,10 +486,13 @@ function AddFont($family, $style='', $file='', $uni=false)
 		$name = '';
 		$originalsize = 0;
 		$ttfstat = stat($ttffilename);
-		if (file_exists($unifilename.'.mtx.php')) {
-			include($unifilename.'.mtx.php');
-		}
-		if (!isset($type) ||  !isset($name) || $originalsize != $ttfstat['size']) {
+		// Ultiorganizer local modification: font metrics caching is disabled.
+		// The cached .mtx.php baked in an absolute font path, which broke PDF
+		// generation whenever the app was deployed to a different directory
+		// than the one where the cache was generated. Always regenerate the
+		// metrics in memory (cheap; PDFs are generated rarely) so the font
+		// path is resolved from the current install location every time.
+		if (true) {
 			$ttffile = $ttffilename;
 			require_once($this->fontpath.'unifont/ttfonts.php');
 			$ttf = new TTFontFile();
@@ -509,30 +512,10 @@ function AddFont($family, $style='', $file='', $uni=false)
 			$ut = round($ttf->underlineThickness);
 			$originalsize = $ttfstat['size']+0;
 			$type = 'TTF';
-			// Generate metrics .php file
-			$s='<?php'."\n";
-			$s.='$name=\''.$name."';\n";
-			$s.='$type=\''.$type."';\n";
-			$s.='$desc='.var_export($desc,true).";\n";
-			$s.='$up='.$up.";\n";
-			$s.='$ut='.$ut.";\n";
-			$s.='$ttffile=\''.$ttffile."';\n";
-			$s.='$originalsize='.$originalsize.";\n";
-			$s.='$fontkey=\''.$fontkey."';\n";
-			$s.="?>";
-			if (is_writable(dirname($this->fontpath.'unifont/'.'x'))) {
-				$fh = fopen($unifilename.'.mtx.php',"w");
-				fwrite($fh,$s,strlen($s));
-				fclose($fh);
-				$fh = fopen($unifilename.'.cw.dat',"wb");
-				fwrite($fh,$cw,strlen($cw));
-				fclose($fh);
-				@unlink($unifilename.'.cw127.php');
-			}
+			// Ultiorganizer local modification: the metrics cache (.mtx.php /
+			// .cw.dat) is intentionally not written; see the note above. This
+			// also removes the need for a writable font directory.
 			unset($ttf);
-		}
-		else {
-			$cw = @file_get_contents($unifilename.'.cw.dat'); 
 		}
 		$i = count($this->fonts)+1;
 		if(!empty($this->AliasNbPages))
@@ -2015,38 +1998,20 @@ protected function _putfonts()
 }
 
 protected function _putTTfontwidths($font, $maxUni) {
-	if (file_exists($font['unifilename'].'.cw127.php')) {
-		include($font['unifilename'].'.cw127.php') ;
-		$startcid = 128;
-	}
-	else {
-		$rangeid = 0;
-		$range = array();
-		$prevcid = -2;
-		$prevwidth = -1;
-		$interval = false;
-		$startcid = 1;
-	}
-	$cwlen = $maxUni + 1; 
+	// Ultiorganizer local modification: width-range caching (.cw127.php) is
+	// disabled (see AddFont). Always compute the ranges from scratch so no
+	// writable font directory is required; the result is identical.
+	$rangeid = 0;
+	$range = array();
+	$prevcid = -2;
+	$prevwidth = -1;
+	$interval = false;
+	$startcid = 1;
+	$cwlen = $maxUni + 1;
 
 	// for each character
 	for ($cid=$startcid; $cid<$cwlen; $cid++) {
-		if ($cid==128 && (!file_exists($font['unifilename'].'.cw127.php'))) {
-			if (is_writable(dirname($this->fontpath.'unifont/x'))) {
-				$fh = fopen($font['unifilename'].'.cw127.php',"wb");
-				$cw127='<?php'."\n";
-				$cw127.='$rangeid='.$rangeid.";\n";
-				$cw127.='$prevcid='.$prevcid.";\n";
-				$cw127.='$prevwidth='.$prevwidth.";\n";
-				if ($interval) { $cw127.='$interval=true'.";\n"; }
-				else { $cw127.='$interval=false'.";\n"; }
-				$cw127.='$range='.var_export($range,true).";\n";
-				$cw127.="?>";
-				fwrite($fh,$cw127,strlen($cw127));
-				fclose($fh);
-			}
-		}
-		if ((!isset($font['cw'][$cid*2]) || !isset($font['cw'][$cid*2+1])) || 
+		if ((!isset($font['cw'][$cid*2]) || !isset($font['cw'][$cid*2+1])) ||
                     ($font['cw'][$cid*2] == "\00" && $font['cw'][$cid*2+1] == "\00")) { continue; }
 
 		$width = (ord($font['cw'][$cid*2]) << 8) + ord($font['cw'][$cid*2+1]);

--- a/user/addscoresheet.php
+++ b/user/addscoresheet.php
@@ -674,14 +674,14 @@ foreach ($scores as $row) {
     }
 
     if (intval($row['iscallahan'])) {
-        echo "<td class='center' style='width:50px;$style_mid'><input class='input' onkeyup=\"validNumberX(this);\" id='pass$i' name='pass$i' maxlength='3' size='4' value='XX'/></td>";
+        echo "<td class='center' style='width:50px;$style_mid'><input class='input' onkeyup=\"validNumberX(this);\" inputmode='numeric' pattern='[0-9]*' id='pass$i' name='pass$i' maxlength='3' size='4' value='XX'/></td>";
     } else {
         $n = PlayerNumber($row['assist'], $gameId);
         if ($n < 0) {
             $n = "";
         }
 
-        echo "<td class='center' style='width:50px;$style_mid'><input class='input' onkeyup=\"validNumberX(this);\" id='pass$i' name='pass$i' maxlength='3' size='4' value='$n'/></td>";
+        echo "<td class='center' style='width:50px;$style_mid'><input class='input' onkeyup=\"validNumberX(this);\" inputmode='numeric' pattern='[0-9]*' id='pass$i' name='pass$i' maxlength='3' size='4' value='$n'/></td>";
     }
 
     $n = PlayerNumber($row['scorer'], $gameId);
@@ -705,7 +705,7 @@ for ($i; $i < $maxscores; $i++) {
     echo "<td class='center' style='width:25px;color:#B0B0B0;'>", $i + 1, "</td>\n";
     echo "<td class='center' style='width:40px;$style_left' onclick=\"clickButton('hteam$i');\"><input onclick=\"updateScores($i);\" onkeyup=\"moveNext($i,event);\" id='hteam$i' name='team$i' type='radio' value='H' /></td>";
     echo "<td class='center' style='width:40px;$style_mid' onclick=\"clickButton('ateam$i');\"><input onclick=\"updateScores($i);\" onkeyup=\"moveNext($i,event);\" id='ateam$i' name='team$i' type='radio' value='A' /></td>";
-    echo "<td class='center' style='width:50px;$style_mid'><input class='input' onkeyup=\"validNumberX(this);\" id='pass$i' name='pass$i' size='3' maxlength='2'/></td>";
+    echo "<td class='center' style='width:50px;$style_mid'><input class='input' onkeyup=\"validNumberX(this);\" inputmode='numeric' pattern='[0-9]*' id='pass$i' name='pass$i' size='3' maxlength='2'/></td>";
     echo "<td  class='center' style='width:50px;$style_mid'><input class='input' onkeyup=\"validNumber(this);\" inputmode='numeric' pattern='[0-9]*' id='goal$i' name='goal$i' size='3' maxlength='2'/></td>";
     if (!$hideTimeOnScoresheet) {
         echo "<td style='width:60px;$style_mid'><input class='input' onkeyup=\"validTime(this);\" inputmode='decimal' pattern='[0-9.,:;]*' id='time$i' name='time$i' maxlength='8' size='8'/></td>";

--- a/user/addscoresheet.php
+++ b/user/addscoresheet.php
@@ -674,14 +674,14 @@ foreach ($scores as $row) {
     }
 
     if (intval($row['iscallahan'])) {
-        echo "<td class='center' style='width:50px;$style_mid'><input class='input' onkeyup=\"validNumberX(this);\" inputmode='numeric' pattern='[0-9]*' id='pass$i' name='pass$i' maxlength='3' size='4' value='XX'/></td>";
+        echo "<td class='center' style='width:50px;$style_mid'><input class='input' onkeyup=\"validNumberX(this);\" inputmode='numeric' pattern='[0-9xX]*' id='pass$i' name='pass$i' maxlength='3' size='4' value='XX'/></td>";
     } else {
         $n = PlayerNumber($row['assist'], $gameId);
         if ($n < 0) {
             $n = "";
         }
 
-        echo "<td class='center' style='width:50px;$style_mid'><input class='input' onkeyup=\"validNumberX(this);\" inputmode='numeric' pattern='[0-9]*' id='pass$i' name='pass$i' maxlength='3' size='4' value='$n'/></td>";
+        echo "<td class='center' style='width:50px;$style_mid'><input class='input' onkeyup=\"validNumberX(this);\" inputmode='numeric' pattern='[0-9xX]*' id='pass$i' name='pass$i' maxlength='3' size='4' value='$n'/></td>";
     }
 
     $n = PlayerNumber($row['scorer'], $gameId);
@@ -705,7 +705,7 @@ for ($i; $i < $maxscores; $i++) {
     echo "<td class='center' style='width:25px;color:#B0B0B0;'>", $i + 1, "</td>\n";
     echo "<td class='center' style='width:40px;$style_left' onclick=\"clickButton('hteam$i');\"><input onclick=\"updateScores($i);\" onkeyup=\"moveNext($i,event);\" id='hteam$i' name='team$i' type='radio' value='H' /></td>";
     echo "<td class='center' style='width:40px;$style_mid' onclick=\"clickButton('ateam$i');\"><input onclick=\"updateScores($i);\" onkeyup=\"moveNext($i,event);\" id='ateam$i' name='team$i' type='radio' value='A' /></td>";
-    echo "<td class='center' style='width:50px;$style_mid'><input class='input' onkeyup=\"validNumberX(this);\" inputmode='numeric' pattern='[0-9]*' id='pass$i' name='pass$i' size='3' maxlength='2'/></td>";
+    echo "<td class='center' style='width:50px;$style_mid'><input class='input' onkeyup=\"validNumberX(this);\" inputmode='numeric' pattern='[0-9xX]*' id='pass$i' name='pass$i' size='3' maxlength='2'/></td>";
     echo "<td  class='center' style='width:50px;$style_mid'><input class='input' onkeyup=\"validNumber(this);\" inputmode='numeric' pattern='[0-9]*' id='goal$i' name='goal$i' size='3' maxlength='2'/></td>";
     if (!$hideTimeOnScoresheet) {
         echo "<td style='width:60px;$style_mid'><input class='input' onkeyup=\"validTime(this);\" inputmode='decimal' pattern='[0-9.,:;]*' id='time$i' name='time$i' maxlength='8' size='8'/></td>";


### PR DESCRIPTION
## Summary

Two independent bug fixes.

### Fix PDF font crash by disabling tFPDF metrics cache
tFPDF cached Unicode-font metrics into `lib/tfpdf/font/unifont/*.mtx.php` and baked the font's **absolute path** into the cache. When the cache was generated under one install path but the app later ran under another, the embed step `fopen()`'d the stale path and `die()`'d, breaking all PDF generation (e.g. `Can't open file /home/.../DejaVuSansCondensed.ttf` seen in the production error log).

- Disable the font metrics cache entirely in `tfpdf.php` (`AddFont()` and `_putTTfontwidths()`): no longer read or write `*.mtx.php`, `*.cw.dat`, or `*.cw127.php`.
- Metrics are regenerated in memory on each run, so the font path is always resolved from the current install location, and **no writable font directory is required**.
- Cost is negligible since PDFs are generated rarely. Existing stale cache files become inert.
- The local modification is recorded in `docs/codebase-notes.md` so it is re-applied after any future tFPDF upgrade.

Verified by reproducing both directions: original code → the exact production error; patched code → PDF renders and no cache files are written. `composer check` (PHP-CS-Fixer + PHPStan) clean.

### Add numeric keyboard hint to scoresheet assist inputs
The assist (pass) inputs on the scoresheet lacked the numeric keyboard hint that the goal inputs already have, so mobile keyboards opened in text mode. Added `inputmode='numeric' pattern='[0-9]*'` to all three pass inputs. The `validNumberX` handler still permits `X`/`XX` for the rare Callahan case, where the user can switch the keyboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)