### PR TITLE
[codex] Improve architecture and README documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ Pre-commit hooks remain the fast local gate; CI is the source of truth for what 
 
 ### Core architecture
 
+- `docs/architecture.md`: bird's-eye orientation — the core/surfaces shape, request lifecycle, domain model, and cross-cutting layers. Start here.
 - `docs/api.md`: API structure, constraints, and examples.
 - `docs/codebase-notes.md`: third-party components, PDF generation, plugins, and customization notes.
 - `docs/customization.md`: skin color token system, recoloring a skin with tokens, the dark-mode approach, and customization verification.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The repository is organized as follows:
 * **api** JSON API entry points and versioned routing.
 * **cust** Skins and installation-specific customizations.
 * **login** Authentication and password reset entry points.
-* **mobile**, **scorekeeper**, **spiritkeeper**, **ext** Specialized entry points. `mobile/` is legacy and deprecated; `scorekeeper/` and `spiritkeeper/` are the supported replacements for the old mobile administration UI.
+* **mobile**, **scorekeeper**, **spiritkeeper**, **timekeeper**, **ext** Specialized entry points. `mobile/` is legacy and deprecated; `scorekeeper/` and `spiritkeeper/` are the supported replacements for the old mobile administration UI, and `timekeeper/` is a standalone, public WFDF time-limit signalling aid.
 * **images**, **locale**, **plugins** Static assets, translations, and plugin code.
 * **script** Client-side JavaScript assets.
 * **conf**, **sql** Configuration and database assets that should not be exposed by the web server.
@@ -93,6 +93,8 @@ API. See `docs/api.md` for endpoint examples and current constraints.
 
 Ultiorganizer was first introduced at the 2002 World Championships in Turku, after already being used by the Finnish Flying Disc Association from 1999. Even though the codebase has since been fully rewritten on a modern technology stack, the original vision has remained the same: a free, open, and reliable live-scoring system for Ultimate. This journey has only been possible because of the many people who use the system in real events and continuously improve it through feedback, testing, and patches.
 
+Ultiorganizer's current PHP codebase is mostly authored by **Kari Hulkko** (**ktolonen**), who also maintains the system in the Finnish Flying Disc Association (SLKL) context.
+
 Special thanks to **Pasi Niemi**, whose early and significant contributions helped launch the rewrite of the scoring system in PHP.
 
 Special thanks to **Bruno Gravato** for years of practical development work on a long-running fork used by major Ultimate organizations, including BULA, WFDF, EUF, and national federations. Bruno’s contributions include substantial maintenance and feature work beyond the 2014 upstream baseline.
@@ -100,15 +102,16 @@ Special thanks to **Bruno Gravato** for years of practical development work on a
 Thanks as well to **Justin Palmer** and **Patrick** for the [Live by BULA](https://github.com/layoutd/live-by-bula) collaboration.
 
 Contributors:
+- Alejandro Molina
+- Artsa
 - Asmo Soinio
 - Bruno Gravato
-- Hartti Suomela
-- Juha Jalovaara
-- Kari
-- Artsa
-- Pasi Niemi
 - cschaffner
-- Les
-- Plinio Moreno
+- Hartti Suomela
 - Jonathan Potts
+- Juha Jalovaara
+- Kari Hulkko
+- Les
+- Pasi Niemi
+- Plinio Moreno
 - Steffen Mecke

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This directory collects general project documentation.
 
 ### Core architecture
 
+- `architecture.md`: bird's-eye orientation — the core/surfaces shape, request lifecycle, domain model, and cross-cutting layers. Start here.
 - `api.md`: API structure, constraints, and examples.
 - `codebase-notes.md`: third-party components, PDF generation, plugins, and customization notes.
 - `customization.md`: skin color token system, recoloring a skin with tokens, the dark-mode approach, and customization verification.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,75 @@
+# Architecture
+
+A bird's-eye orientation to how Ultiorganizer fits together. Read this first, then
+follow the links into the topic docs for detail. It deliberately stays high-level and
+does not duplicate them.
+
+Ultiorganizer is a PHP web app for running Ultimate tournaments: scheduling, score
+keeping, standings, spirit scoring, and public results.
+
+## The shape: one core, many surfaces
+
+There is a single shared core — `index.php`, the `lib/` helpers, and the database —
+and several thin entry points layered on top of it:
+
+- `index.php`: the main web app (admin and logged-in user pages).
+- `scorekeeper/`, `spiritkeeper/`, `timekeeper/`: standalone game-day apps.
+- `mobile/`: the deprecated legacy operator interface, kept only for compatibility.
+- `api/`: the JSON API.
+- `ext/`: public external outputs (RSS, CSV, XML, widgets).
+- `login/`: the shared login surface.
+
+The surfaces differ mostly in routing and UI; they all reach the same data through
+`lib/`. See [routing.md](routing.md) for the full entry-point list and guards.
+
+## Request lifecycle
+
+A typical main-app request flows like this:
+
+1. `index.php` boots and defines `UO_ROUTED_VIEW`.
+2. It resolves the page from the `?view=...` query parameter.
+3. The page's area auth wrapper (`admin/auth.php`, `user/auth.php`, ...) enforces
+   access; include-only files are protected by the `*.guard.php` guards.
+4. The page handler orchestrates the work but holds no SQL of its own.
+5. All SQL and data access live in `lib/*.functions.php`, which call the wrappers in
+   `lib/database.php`.
+6. `lib/database.php` serves reads through two caches when applicable (see below).
+7. Output is rendered with `localization.php` — gettext strings, `U_()` translations,
+   and the skin's CSS token cascade.
+
+The page-layer-must-not-touch-SQL rule is enforced; see [database-access.md](database-access.md).
+
+## Domain model spine
+
+The competition data nests like this:
+
+```
+event (season) -> division (series) -> pool -> game <-> teams / players
+```
+
+- User-facing **event** / **division** are `season` / `series` in code and the schema
+  (see [terminology.md](terminology.md) for the naming mismatch).
+- A **pool** has one of four types (round-robin, playoff, swiss, cross-match), each
+  with its own ranking resolver writing `activerank`; see [ranking.md](ranking.md).
+- `uo_game_pool` is the source of truth for which pool(s) a game belongs to; the game
+  row itself carries no pool. Scheduling is built on top; see [schedule.md](schedule.md).
+- The detailed game record (roster, goals, events, timeouts, note) is a concept
+  spanning several tables, not one table; see [scoresheet.md](scoresheet.md).
+
+A file-by-file map of the helpers lives in [lib-index.md](lib-index.md).
+
+## Cross-cutting layers
+
+Concerns that run through most requests, each with its own doc:
+
+- **Auth & permissions** — roles and enforcement helpers: [permissions.md](permissions.md).
+- **Configuration** — the SYSTEM / INSTALLATION / EVENT taxonomy: [configuration-flags.md](configuration-flags.md).
+- **Translations** — gettext, static localized files, and DB-backed `U_()`: [translations.md](translations.md).
+- **Caching** — request-local ([runtime-cache.md](runtime-cache.md)) and cross-request TTL ([persistent-cache.md](persistent-cache.md)).
+- **Customization** — skins and the CSS color-token cascade: [customization.md](customization.md).
+- **Database changes** — versioned upgrades and migrations: [database-upgrades.md](database-upgrades.md).
+
+## Where to go next
+
+[README.md](README.md) is the full index of topic docs. For implementation details
+that do not belong in any single subsystem doc, see [codebase-notes.md](codebase-notes.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ keeping, standings, spirit scoring, and public results.
 
 ## The shape: one core, many surfaces
 
-There is a single shared core — `index.php`, the `lib/` helpers, and the database —
+There is a single shared core (`index.php`, the `lib/` helpers, and the database)
 and several thin entry points layered on top of it:
 
 - `index.php`: the main web app (admin and logged-in user pages).
@@ -34,7 +34,7 @@ A typical main-app request flows like this:
 5. All SQL and data access live in `lib/*.functions.php`, which call the wrappers in
    `lib/database.php`.
 6. `lib/database.php` serves reads through two caches when applicable (see below).
-7. Output is rendered with `localization.php` — gettext strings, `U_()` translations,
+7. Output is rendered with `localization.php`: gettext strings, `U_()` translations,
    and the skin's CSS token cascade.
 
 The page-layer-must-not-touch-SQL rule is enforced; see [database-access.md](database-access.md).
@@ -62,12 +62,12 @@ A file-by-file map of the helpers lives in [lib-index.md](lib-index.md).
 
 Concerns that run through most requests, each with its own doc:
 
-- **Auth & permissions** — roles and enforcement helpers: [permissions.md](permissions.md).
-- **Configuration** — the SYSTEM / INSTALLATION / EVENT taxonomy: [configuration-flags.md](configuration-flags.md).
-- **Translations** — gettext, static localized files, and DB-backed `U_()`: [translations.md](translations.md).
-- **Caching** — request-local ([runtime-cache.md](runtime-cache.md)) and cross-request TTL ([persistent-cache.md](persistent-cache.md)).
-- **Customization** — skins and the CSS color-token cascade: [customization.md](customization.md).
-- **Database changes** — versioned upgrades and migrations: [database-upgrades.md](database-upgrades.md).
+- **Auth & permissions** - roles and enforcement helpers: [permissions.md](permissions.md).
+- **Configuration** - the SYSTEM / INSTALLATION / EVENT taxonomy: [configuration-flags.md](configuration-flags.md).
+- **Translations** - gettext, static localized files, and DB-backed `U_()`: [translations.md](translations.md).
+- **Caching** - request-local ([runtime-cache.md](runtime-cache.md)) and cross-request TTL ([persistent-cache.md](persistent-cache.md)).
+- **Customization** - skins and the CSS color-token cascade: [customization.md](customization.md).
+- **Database changes** - versioned upgrades and migrations: [database-upgrades.md](database-upgrades.md).
 
 ## Where to go next
 

--- a/docs/lib-index.md
+++ b/docs/lib-index.md
@@ -21,8 +21,10 @@ Use this index to find existing shared helpers before adding new utility code or
 - `lib/game.functions.php`: game CRUD, results, scoresheet events, media links, player assignments, scheduling, live timing, and spirit table output.
 - `lib/image.functions.php`: uploaded image lookup/removal plus JPEG conversion and thumbnail generation.
 - `lib/include_only.guard.php`: include-time guard for files that must not be invoked directly.
+- `lib/locale.functions.php`: gettext locale resolution, installed/carrier-locale discovery, and locale activation.
 - `lib/location.functions.php`: location CRUD, search payloads, and localized location info text.
 - `lib/logging.functions.php`: audit/event logs, visitor/page-load logs, and helper log writers per domain action.
+- `lib/pdf.interfaces.php`: PDF purpose-file interfaces (`SchedulePdf`, `ScoreSheetPdf`, `BundledPlayerListScoreSheet`) implemented by `cust/*/pdfschedule.php` and `pdfscoresheet.php`.
 - `lib/player.functions.php`: player/profile CRUD, roster/profile sync, player stats, profile media, and CSV export.
 - `lib/plugin.functions.php`: plugin manifest lookup by category/type/format.
 - `lib/pool.functions.php`: pool/template CRUD, pool teams and games, standings-derived moves, playoff generation, swiss helpers, and CSV export.

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -14,6 +14,7 @@
 - `mobile/index.php`: deprecated legacy mobile administration entry point kept for compatibility.
 - `scorekeeper/index.php`: touchscreen scorekeeper entry point.
 - `spiritkeeper/index.php`: standalone Spiritkeeper entry point.
+- `timekeeper/index.php`: standalone, public Timekeeper entry point (no login).
 - `login/index.php` and `ext/index.php`: specialized entry points for those areas.
 
 `mobile/` is no longer the recommended operator surface. Use `scorekeeper/` for scorekeeping workflows and `spiritkeeper/` for spirit-entry workflows.
@@ -21,7 +22,7 @@
 ## Standalone vs include-only files
 
 - Not every `.php` file in the repository is a valid public endpoint.
-- Supported standalone entry points are the app index files such as `index.php`, `scorekeeper/index.php`, `spiritkeeper/index.php`, `mobile/index.php`, `login/index.php`, `ext/index.php`, and API entry points under `api/`.
+- Supported standalone entry points are the app index files such as `index.php`, `scorekeeper/index.php`, `spiritkeeper/index.php`, `timekeeper/index.php`, `mobile/index.php`, `login/index.php`, `ext/index.php`, and API entry points under `api/`.
 - Many subdirectory files are include-only views or helpers and should not bootstrap themselves when hit directly.
 - Include-only PHP files are guarded in code where cross-server portability matters:
   - `lib/` uses `lib/include_only.guard.php`

--- a/docs/scoresheet.md
+++ b/docs/scoresheet.md
@@ -229,7 +229,6 @@ Relevant columns:
 - `visitorscore`
 - `reservation`
 - `time`
-- `pool`
 - `halftime`
 - `official`
 - `isongoing`


### PR DESCRIPTION
## Summary

- add a concise architecture overview and link it from both documentation indexes
- document the Timekeeper entry point and missing shared-library files
- correct the scoresheet schema description by removing the nonexistent `uo_game.pool` column
- update the root README entry-point overview, maintainer credit, and contributor list

## Why

The documentation had several orientation gaps and small areas of drift from the current codebase. This gives contributors a clearer starting point and brings the entry-point, library, and schema references back in sync.

## Impact

Documentation only; runtime behavior is unchanged.

## Validation

- `git diff --check origin/master...HEAD`
- reviewed the complete branch diff against `master`