### PR TITLE
[codex] Automate GitHub release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  publish:
+    name: Build and publish release packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # The release script uses Git metadata and the release must be built
+          # from the exact tag that triggered this workflow.
+          fetch-depth: 0
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+      - name: Verify tag and application version
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag_version="${GITHUB_REF_NAME#v}"
+          tag_version="${tag_version#.}"
+          app_version="$(php -r '$version = include "version.php"; echo $version;')"
+          if [[ "$tag_version" != "$app_version" ]]; then
+            echo "Tag version '$tag_version' does not match version.php '$app_version'." >&2
+            exit 1
+          fi
+      - name: Build install and update packages
+        run: |
+          bash docs/release/build-release.sh --install --yes
+          bash docs/release/build-release.sh --update --yes
+      - name: Create checksums
+        working-directory: dist
+        run: sha256sum ./*.zip > SHA256SUMS
+      - name: Store workflow artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ultiorganizer-${{ github.ref_name }}
+          path: dist/
+          if-no-files-found: error
+          retention-days: 30
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            dist/*.zip \
+            dist/SHA256SUMS \
+            --verify-tag \
+            --generate-notes \
+            --title "Ultiorganizer $GITHUB_REF_NAME"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -42,6 +42,28 @@ docs/release/build-release.sh --cust wfdf
 `cust/default` is always included. Repeat `--cust` or pass a comma-separated list to include more than one non-default customization.
 When customizations are selected, the package filename includes the selected customization set, such as `ultiorganizer-update-cust-default-wfdf-4.0-abc1234.zip`.
 
+## Publish a GitHub release
+
+The Release workflow (`.github/workflows/release.yml`) runs when a tag whose name starts with `v` is pushed to GitHub. It checks that the tag version matches `version.php`, calls the release script to build both the install and update packages, and creates a GitHub Release with generated release notes.
+
+To publish a release after the `master` branch has passed CI:
+
+```sh
+git switch master
+git pull --ff-only
+git tag -a v.4.0 -m "Ultiorganizer 4.0"
+git push origin v.4.0
+```
+
+The repository's existing tags use `v.<version>`, as in `v.4.0`; `v4.0` is also accepted. The version after either prefix must exactly match the value in `version.php`.
+
+The workflow stores the following files in two places:
+
+- the install ZIP, update ZIP, and `SHA256SUMS` are permanent assets on the GitHub Release
+- the same files are retained for 30 days as an artifact of the workflow run
+
+Do not create the GitHub Release manually before pushing the tag because the workflow creates it. If the workflow fails before publishing, fix the problem, delete the tag locally and on GitHub, and then create and push the corrected tag.
+
 ## Install from a release package
 
 To install Ultiorganizer on a server:


### PR DESCRIPTION
## Summary

- add a tag-triggered GitHub Actions release workflow
- validate the tag against `version.php`
- build install and update ZIPs with the existing release script
- attach ZIPs and SHA-256 checksums to the GitHub Release and retain a workflow artifact
- document the maintainer release process

## Why

Release packages were buildable locally and in CI, but publishing a GitHub Release and retaining its package outputs still required manual work. This automates that handoff while keeping the existing packaging script as the single source of truth.

## Impact

Pushing a matching `v*` tag now creates a GitHub Release with generated notes, both package types, and checksums. Normal branch and pull-request CI behavior is unchanged.

## Checks

- built install and update packages with `docs/release/build-release.sh --yes`
- verified both ZIP archives with `unzip -t`
- exercised the `v.4.0` tag/version comparison
- ran `git diff --check`
- completed the user-language review with no findings
