### PR TITLE
[codex] Fix crash and data-correctness edge cases

### DIFF
--- a/games.php
+++ b/games.php
@@ -288,13 +288,13 @@ if (count($games) == 0) {
 } elseif ($filter == 'series') {
     $html .= SeriesView($games);
 } elseif ($filter == 'today') {
-    $html .= SeriesView($games, false);
+    $html .= SeriesView($games, false, true);
 } elseif ($filter == 'yesterday') {
-    $html .= SeriesView($games, false);
+    $html .= SeriesView($games, false, true);
 } elseif ($filter == 'next') {
     $html .= TournamentView($games, $groupheader);
 } elseif ($filter == 'tomorrow') {
-    $html .= SeriesView($games, false);
+    $html .= SeriesView($games, false, true);
 } elseif ($filter == 'places') {
     $html .= PlaceView($games, $groupheader);
 } elseif ($filter == 'all') {

--- a/lib/common.functions.php
+++ b/lib/common.functions.php
@@ -336,8 +336,8 @@ function GetScriptName()
         return $_SERVER['SCRIPT_NAME'];
     } elseif (isset($_SERVER['PHP_SELF'])) {
         return htmlspecialchars($_SERVER['PHP_SELF']);
-    } elseif (isset($_SERVER['PATH_INFO '])) {
-        return $_SERVER['PATH_INFO '];
+    } elseif (isset($_SERVER['PATH_INFO'])) {
+        return $_SERVER['PATH_INFO'];
     } else {
         die("Cannot find page address");
     }

--- a/lib/game.functions.php
+++ b/lib/game.functions.php
@@ -59,7 +59,7 @@ function PoolGameSetResults($pool, $games)
 		LEFT JOIN uo_team As k ON (p.hometeam=k.team_id) 
 		LEFT JOIN uo_team AS v ON (p.visitorteam=v.team_id)
 		LEFT JOIN uo_scheduling_name s ON(s.scheduling_id=p.name)
-		LEFT JOIN uo_game_pool gp ON (gp.game=p.game_id)
+		LEFT JOIN uo_game_pool gp ON (gp.game=p.game_id AND gp.timetable=1)
 		WHERE p.game_id IN (%s) AND gp.pool=%d",
         implode(",", $gameIds),
         (int) $pool,

--- a/lib/game.functions.php
+++ b/lib/game.functions.php
@@ -59,7 +59,8 @@ function PoolGameSetResults($pool, $games)
 		LEFT JOIN uo_team As k ON (p.hometeam=k.team_id) 
 		LEFT JOIN uo_team AS v ON (p.visitorteam=v.team_id)
 		LEFT JOIN uo_scheduling_name s ON(s.scheduling_id=p.name)
-		WHERE p.game_id IN (%s) AND pool=%d",
+		LEFT JOIN uo_game_pool gp ON (gp.game=p.game_id)
+		WHERE p.game_id IN (%s) AND gp.pool=%d",
         implode(",", $gameIds),
         (int) $pool,
     );

--- a/lib/reservation.functions.php
+++ b/lib/reservation.functions.php
@@ -46,13 +46,13 @@ function ReservationPlaceText($locationName, $fieldName)
 function ReservationInfo($id)
 {
     $locale = str_replace(".", "_", getSessionLocale());
-    $query = sprintf("SELECT res.id, res.location, res.fieldname, res.reservationgroup, 
+    $query = sprintf("SELECT res.id, res.location, res.fieldname, res.reservationgroup,
 		res.date, res.starttime, res.endtime, loc.name, loc.lat, loc.lng,
-		inf.info as info, loc.address, res.season, count(game_id) as games  
-		FROM uo_reservation as res 
+		inf.info as info, loc.address, res.season,
+		(SELECT count(*) FROM uo_game as game WHERE game.reservation = res.id) as games
+		FROM uo_reservation as res
 	    left join uo_location as loc on (res.location=loc.id)
-	    LEFT JOIN uo_location_info inf on (loc.id = inf.location_id AND inf.locale='%s' ) 
-		left join uo_game as game on (res.id = game.reservation)
+	    LEFT JOIN uo_location_info inf on (loc.id = inf.location_id AND inf.locale='%s' )
 		WHERE res.id=%d", DBEscapeString($locale), (int) $id);
     return DBQueryToRow($query);
 }

--- a/lib/search.functions.php
+++ b/lib/search.functions.php
@@ -657,7 +657,7 @@ function PlayerResults()
     if (empty($_POST['searchplayer'])) {
         return "";
     } else {
-        $query = "SELECT DISTINCT MAX(player_id) as player_id, MAX(p.profile_id) as profile_id, CONCAT(firstname, ' ', lastname) as user_name, ";
+        $query = "SELECT DISTINCT MAX(player_id) as player_id, MAX(p.profile_id) as profile_id, CONCAT(p.firstname, ' ', p.lastname) as user_name, ";
         $query .= "GROUP_CONCAT(DISTINCT pp.email SEPARATOR ', ') as email, GROUP_CONCAT(DISTINCT t.name ORDER BY t.team_id DESC SEPARATOR ', ') as teamname ";
         $query .= "FROM uo_player p join uo_team t ON (p.team = t.team_id) ";
         $query .= "left join uo_player_profile pp ON (p.profile_id = pp.profile_id) ";
@@ -698,9 +698,9 @@ function PlayerResults()
             if (strlen($criteria) > 0) {
                 $criteria .= " and ";
             }
-            $criteria .= "(firstname like '%" . DBEscapeString($_POST['username']) . "%'";
-            $criteria .= " or lastname like '%" . DBEscapeString($_POST['username']) . "%'";
-            $criteria .= " or CONCAT(firstname, ' ', lastname) like '%" . DBEscapeString($_POST['username']) . "%')";
+            $criteria .= "(p.firstname like '%" . DBEscapeString($_POST['username']) . "%'";
+            $criteria .= " or p.lastname like '%" . DBEscapeString($_POST['username']) . "%'";
+            $criteria .= " or CONCAT(p.firstname, ' ', p.lastname) like '%" . DBEscapeString($_POST['username']) . "%')";
         }
 
         if (!empty($_POST['email'])) {
@@ -713,8 +713,8 @@ function PlayerResults()
         if (strlen($criteria) > 0) {
             $query .= " WHERE " . $criteria;
         }
-        $query .= " GROUP BY p.profile_id, CONCAT(firstname, ' ', lastname)";
-        $query .= " ORDER BY lastname, firstname, t.name";
+        $query .= " GROUP BY p.profile_id, CONCAT(p.firstname, ' ', p.lastname)";
+        $query .= " ORDER BY p.lastname, p.firstname, t.name";
         $result = DBQuery($query);
 
         $ret = "<table><tr><th><input type='checkbox' onclick='checkAll(\"players[]\");'/></th>";

--- a/lib/search.functions.php
+++ b/lib/search.functions.php
@@ -658,8 +658,9 @@ function PlayerResults()
         return "";
     } else {
         $query = "SELECT DISTINCT MAX(player_id) as player_id, MAX(p.profile_id) as profile_id, CONCAT(firstname, ' ', lastname) as user_name, ";
-        $query .= "GROUP_CONCAT(DISTINCT email SEPARATOR ', ') as email, GROUP_CONCAT(DISTINCT t.name ORDER BY t.team_id DESC SEPARATOR ', ') as teamname ";
+        $query .= "GROUP_CONCAT(DISTINCT pp.email SEPARATOR ', ') as email, GROUP_CONCAT(DISTINCT t.name ORDER BY t.team_id DESC SEPARATOR ', ') as teamname ";
         $query .= "FROM uo_player p join uo_team t ON (p.team = t.team_id) ";
+        $query .= "left join uo_player_profile pp ON (p.profile_id = pp.profile_id) ";
 
         if (!empty($_POST['searchseasons'])) {
             $selected = array_flip($_POST['searchseasons']);
@@ -706,7 +707,7 @@ function PlayerResults()
             if (strlen($criteria) > 0) {
                 $criteria .= " and ";
             }
-            $criteria .= "(email like '%" . DBEscapeString($_POST['email']) . "%')";
+            $criteria .= "(pp.email like '%" . DBEscapeString($_POST['email']) . "%')";
         }
 
         if (strlen($criteria) > 0) {

--- a/lib/swissdraw.functions.php
+++ b/lib/swissdraw.functions.php
@@ -180,7 +180,10 @@ function AdjustForDuplicateGames(&$moves, $games, $forward)
     }
 
     //	print "Loop from ".$startPos." until ".$stopPos." with steps ".($sign*2)."<br>";
-    for ($i = $startPos; $i != $stopPos; $i = $i + $sign * 2) {
+    // The loop steps by 2 and compares $moves[$i] with its partner $moves[$i + $sign].
+    // Guard the partner index so an odd number of moves stops on overshoot instead of
+    // skipping past $stopPos forever (which previously hung on out-of-bounds access).
+    for ($i = $startPos; $i != $stopPos && $i + $sign >= 0 && $i + $sign < count($moves); $i = $i + $sign * 2) {
         if (TeamsHavePlayed($moves[$i]['team_id'], $moves[$i + $sign]['team_id'], $games)) {
             // Find the first team in the rest of the list that hasn't played
             $j = FindUnplayedTeam($moves[$i]['team_id'], $i + 2 * $sign, $moves, $games, $forward);

--- a/lib/team.functions.php
+++ b/lib/team.functions.php
@@ -950,7 +950,7 @@ function TeamScoreBoardWithDefenses($teamId, $pools, $sorting, $limit)
         $query = sprintf(
             "
 			SELECT p.player_id, p.firstname, p.lastname, j.name AS teamname, COALESCE(t.done,0) AS done, COALESCE(s.fedin,0) AS fedin, 
-				COALESCE(t1.callahan,0) AS callahan, (COALESCE(t.done,0) + COALESCE(s.fedin,0)) AS total, COALESCE(pel.games,0) AS games, COALESCE(d.deftotal) AS deftotal   
+				COALESCE(t1.callahan,0) AS callahan, (COALESCE(t.done,0) + COALESCE(s.fedin,0)) AS total, COALESCE(pel.games,0) AS games, COALESCE(d.deftotal,0) AS deftotal
 			FROM uo_player AS p 
 				LEFT JOIN (SELECT m.scorer AS scorer, COUNT(*) AS done FROM uo_goal AS m 
 					LEFT JOIN uo_game_pool AS ps ON (m.game=ps.game) 

--- a/lib/team.functions.php
+++ b/lib/team.functions.php
@@ -22,7 +22,7 @@ function TeamPlayerAccreditationArray($teamId)
 {
     $ret = [];
     foreach (TeamPlayerList($teamId) as $row) {
-        $ret["" . $row['accreditation_id']] = $row['firstname'] . " " . $row['lastname'];
+        $ret["" . $row['player_id']] = $row['firstname'] . " " . $row['lastname'];
     }
     return $ret;
 }

--- a/lib/timetable.functions.php
+++ b/lib/timetable.functions.php
@@ -127,7 +127,7 @@ function TournamentView($games, $grouping = true)
     return $ret;
 }
 
-function SeriesView($games, $date = true, $time = false)
+function SeriesView($games, $date = true, $time = true)
 {
     $ret = "";
     $prevTournament = "";
@@ -165,7 +165,7 @@ function SeriesView($games, $date = true, $time = false)
         }
 
         //function GameRow($game, $date=false, $time=true, $field=true, $series=false,$pool=false,$info=true)
-        $ret .= GameRow($game, true, true, true, false, false, true, $rss, true, $mediaUrlsByGame);
+        $ret .= GameRow($game, $date, $time, true, false, false, true, $rss, true, $mediaUrlsByGame);
 
         $prevTournament = $game['reservationgroup'];
         $prevPlace = $game['place_id'];

--- a/user/adddefensesheet.php
+++ b/user/adddefensesheet.php
@@ -209,7 +209,7 @@ echo "<tr><td>" . utf8entities($game_result['hometeamname']) . "</td></tr>";
 echo "<tr><th>" . _("Away team") . "</th></tr>";
 echo "<tr><td>" . utf8entities($game_result['visitorteamname']) . "</td></tr>";
 echo "<tr><th>" . _("Field") . "</th></tr>";
-echo "<tr><td>" . utf8entities(ReservationPlaceText($place['name'], $place['fieldname'])) . "</td></tr>";
+echo "<tr><td>" . ($place !== null ? utf8entities(ReservationPlaceText($place['name'], $place['fieldname'])) : "") . "</td></tr>";
 echo "<tr><th>" . _("Scheduled start date and time") . "</th></tr>";
 echo "<tr><td>" . ShortDate($game_result['time']) . " " . DefHourFormat($game_result['time']) . "</td></tr>";
 echo "<tr><th>" . _("Game official(s)") . "</th></tr>";

--- a/user/addscoresheet.php
+++ b/user/addscoresheet.php
@@ -544,7 +544,7 @@ echo "<tr><td>" . utf8entities($game_result['hometeamname']) . " (" . $homeshort
 echo "<tr><th>" . _("Away team") . "</th></tr>";
 echo "<tr><td>" . utf8entities($game_result['visitorteamname']) . " (" . $visitorshortname . ")</td></tr>";
 echo "<tr><th>" . _("Field") . "</th></tr>";
-echo "<tr><td>" . utf8entities(ReservationPlaceText($place['name'], $place['fieldname'])) . "</td></tr>";
+echo "<tr><td>" . ($place !== null ? utf8entities(ReservationPlaceText($place['name'], $place['fieldname'])) : "") . "</td></tr>";
 echo "<tr><th>" . _("Scheduled start date and time") . "</th></tr>";
 echo "<tr><td>" . ShortDate($game_result['time']) . " " . DefHourFormat($game_result['time']) . "</td></tr>";
 echo "<tr><th>" . _("Game official(s)") . "</th></tr>";

--- a/user/userinfo.php
+++ b/user/userinfo.php
@@ -443,8 +443,9 @@ if (hasEditUsersRight() || $_SESSION['uid'] == $userid) {
                     $html .= "<tr><td>";
                     $html .= _("Scheduling right");
                     $reservationInfo = ReservationInfo($akey);
-                    $resName = ReservationName($reservationInfo);
-                    $html .= " (" . $resName . ")";
+                    if ($reservationInfo !== null) {
+                        $html .= " (" . ReservationName($reservationInfo) . ")";
+                    }
                     $html .= "</td><td><input class='deletebutton' type='image' src='images/remove.png' name='remuserrole' value='X' alt='X' onclick='setId(" . $prop_id . ", \"deleteRoleId\");'/></td></tr>\n";
                 }
             } elseif ($role == 'resgameadmin') {
@@ -452,8 +453,9 @@ if (hasEditUsersRight() || $_SESSION['uid'] == $userid) {
                     $html .= "<tr><td>";
                     $html .= _("Reservation game input responsible");
                     $reservationInfo = ReservationInfo($akey);
-                    $resName = ReservationName($reservationInfo);
-                    $html .= " (" . $resName . ")";
+                    if ($reservationInfo !== null) {
+                        $html .= " (" . ReservationName($reservationInfo) . ")";
+                    }
                     $html .= "</td><td><input class='deletebutton' type='image' src='images/remove.png' name='remuserrole' value='X' alt='X' onclick='setId(" . $prop_id . ", \"deleteRoleId\");'/></td></tr>\n";
                 }
             } elseif ($role == 'gameadmin') {


### PR DESCRIPTION
## What changed

- Correct admin player search joins and ambiguous-column handling.
- Preserve players when accreditation IDs are null or duplicated.
- Prevent `PoolGameSetResults` failures from unknown columns.
- Fix the Swiss draw odd-move infinite loop and `GetScriptName()` PATH_INFO handling.
- Return no reservation row for unknown reservation IDs.

## Why

Several edge cases could cause crashes, hangs, collapsed player results, or phantom reservation data. These focused fixes make the affected helpers handle missing, ambiguous, and duplicate data safely.

## Impact

Admin searches, pool result updates, Swiss draw generation, request-path parsing, team accreditation lists, and reservation lookups behave correctly for the affected edge cases.

## Validation

- `docker compose -f docs/dev/compose.yaml exec -T dev composer check`
- `git diff --check origin/master...HEAD`