### PR TITLE
Prepare 4.0.0 release

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -63,7 +63,7 @@
                   "status": "ok",
                   "data": {
                     "ultiorganizer": {
-                      "version": "4.0",
+                      "version": "4.0.0",
                       "major": 4,
                       "minor": 0
                     },

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -15,13 +15,21 @@ Maintainers can build a package from the repository root:
 docs/release/build-release.sh
 ```
 
-The package is written to `dist/` with a name like:
+The package is written to `dist/`. The name depends on whether the build is an official tagged release.
+
+For a development build (any commit that is not an exact release tag, or a tagged commit with an unclean working tree), the name appends the short Git commit hash so the package can be traced to its commit:
 
 ```text
-ultiorganizer-install-4.0-abc1234.zip
+ultiorganizer-install-4.0.0-abc1234.zip
 ```
 
-The first part comes from `version.php`; the second part is the current Git commit hash. If the current commit has an exact Git tag and that tag does not match `version.php`, the build prints a warning but still creates the package.
+For an official release — `HEAD` sits on an exact Git tag whose version matches `version.php` and the working tree is clean — the commit hash is omitted, because the tag already identifies the commit:
+
+```text
+ultiorganizer-install-4.0.0.zip
+```
+
+The version part comes from `version.php`. If the current commit has an exact Git tag and that tag does not match `version.php`, the build prints a warning, keeps the commit hash in the name, and still creates the package.
 
 Before building, the script prints the source branch or ref, clean/dirty working tree state, package type, selected customizations, version, commit, and output archive path, then asks for confirmation. For automated builds, pass `--yes` to accept this confirmation.
 
@@ -40,7 +48,7 @@ docs/release/build-release.sh --cust wfdf
 ```
 
 `cust/default` is always included. Repeat `--cust` or pass a comma-separated list to include more than one non-default customization.
-When customizations are selected, the package filename includes the selected customization set, such as `ultiorganizer-update-cust-default-wfdf-4.0-abc1234.zip`.
+When customizations are selected, the package filename includes the selected customization set, such as `ultiorganizer-update-cust-default-wfdf-4.0.0-abc1234.zip`.
 
 ## Publish a GitHub release
 
@@ -51,11 +59,11 @@ To publish a release after the `master` branch has passed CI:
 ```sh
 git switch master
 git pull --ff-only
-git tag -a v.4.0 -m "Ultiorganizer 4.0"
-git push origin v.4.0
+git tag -a v.4.0.0 -m "Ultiorganizer 4.0.0"
+git push origin v.4.0.0
 ```
 
-The repository's existing tags use `v.<version>`, as in `v.4.0`; `v4.0` is also accepted. The version after either prefix must exactly match the value in `version.php`.
+The repository's existing tags use `v.<version>`, as in `v.4.0.0`; `v4.0.0` is also accepted. The version after either prefix must exactly match the value in `version.php`.
 
 The workflow stores the following files in two places:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -29,7 +29,7 @@ For an official release — `HEAD` sits on an exact Git tag whose version matche
 ultiorganizer-install-4.0.0.zip
 ```
 
-The version part comes from `version.php`. If the current commit has an exact Git tag and that tag does not match `version.php`, the build prints a warning, keeps the commit hash in the name, and still creates the package.
+The version part comes from `version.php`. Any tag on the current commit whose version matches `version.php` marks an official release; a matching tag is recognized even when the commit also carries other tags, such as a pre-release tag. If the commit has tags but none match `version.php`, the build prints a warning, keeps the commit hash in the name, and still creates the package.
 
 Before building, the script prints the source branch or ref, clean/dirty working tree state, package type, selected customizations, version, commit, and output archive path, then asks for confirmation. For automated builds, pass `--yes` to accept this confirmation.
 

--- a/docs/release/build-release.sh
+++ b/docs/release/build-release.sh
@@ -274,23 +274,37 @@ validate_customizations
 COMMIT_HASH="$(git rev-parse --short HEAD)"
 CUSTOMIZATION_SUFFIX="$(customization_package_suffix)"
 CUSTOMIZATION_SUMMARY="$(customization_summary)"
-PACKAGE_VERSION="${APP_VERSION}-${COMMIT_HASH}"
-PACKAGE_NAME="ultiorganizer-${PACKAGE_TYPE}${CUSTOMIZATION_SUFFIX}-${PACKAGE_VERSION}"
-ARCHIVE_PATH="${DIST_DIR}/${PACKAGE_NAME}.zip"
 GIT_SOURCE="$(current_git_source)"
 WORKING_TREE_STATE="$(working_tree_state)"
 
-confirm_release_build
-
+# Decide whether this is an official tagged release. HEAD must sit on an exact
+# tag whose normalized version matches version.php, with a clean working tree.
+# Official releases use a plain version string (e.g. 4.0.0); development builds
+# append the commit hash so an untagged package can be traced to its commit.
 EXACT_TAG="$(git describe --exact-match --tags HEAD 2>/dev/null || true)"
+IS_TAGGED_RELEASE=0
 if [[ -n "${EXACT_TAG}" ]]; then
     NORMALIZED_TAG="${EXACT_TAG#v}"
     NORMALIZED_TAG="${NORMALIZED_TAG#V}"
     NORMALIZED_TAG="${NORMALIZED_TAG#.}"
     if [[ "${NORMALIZED_TAG}" != "${APP_VERSION}" ]]; then
         echo "warning: exact tag '${EXACT_TAG}' does not match version.php '${APP_VERSION}'" >&2
+    elif [[ "${WORKING_TREE_STATE}" == "clean" ]]; then
+        IS_TAGGED_RELEASE=1
+    else
+        echo "warning: exact tag '${EXACT_TAG}' matches version.php but the working tree is not clean; including commit hash in package name" >&2
     fi
 fi
+
+if [[ "${IS_TAGGED_RELEASE}" -eq 1 ]]; then
+    PACKAGE_VERSION="${APP_VERSION}"
+else
+    PACKAGE_VERSION="${APP_VERSION}-${COMMIT_HASH}"
+fi
+PACKAGE_NAME="ultiorganizer-${PACKAGE_TYPE}${CUSTOMIZATION_SUFFIX}-${PACKAGE_VERSION}"
+ARCHIVE_PATH="${DIST_DIR}/${PACKAGE_NAME}.zip"
+
+confirm_release_build
 
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "${WORK_DIR}"' EXIT

--- a/docs/release/build-release.sh
+++ b/docs/release/build-release.sh
@@ -277,23 +277,36 @@ CUSTOMIZATION_SUMMARY="$(customization_summary)"
 GIT_SOURCE="$(current_git_source)"
 WORKING_TREE_STATE="$(working_tree_state)"
 
-# Decide whether this is an official tagged release. HEAD must sit on an exact
-# tag whose normalized version matches version.php, with a clean working tree.
+# Decide whether this is an official tagged release. HEAD must carry a tag whose
+# normalized version matches version.php, with a clean working tree. Any tag at
+# HEAD qualifies, so a matching release tag is still recognized when the commit
+# also carries other tags (for example a pre-release tag on the same commit).
 # Official releases use a plain version string (e.g. 4.0.0); development builds
 # append the commit hash so an untagged package can be traced to its commit.
-EXACT_TAG="$(git describe --exact-match --tags HEAD 2>/dev/null || true)"
+HEAD_TAGS="$(git tag --points-at HEAD)"
 IS_TAGGED_RELEASE=0
-if [[ -n "${EXACT_TAG}" ]]; then
-    NORMALIZED_TAG="${EXACT_TAG#v}"
-    NORMALIZED_TAG="${NORMALIZED_TAG#V}"
-    NORMALIZED_TAG="${NORMALIZED_TAG#.}"
-    if [[ "${NORMALIZED_TAG}" != "${APP_VERSION}" ]]; then
-        echo "warning: exact tag '${EXACT_TAG}' does not match version.php '${APP_VERSION}'" >&2
-    elif [[ "${WORKING_TREE_STATE}" == "clean" ]]; then
+MATCHING_TAG=""
+while IFS= read -r head_tag; do
+    if [[ -z "${head_tag}" ]]; then
+        continue
+    fi
+    normalized_tag="${head_tag#v}"
+    normalized_tag="${normalized_tag#V}"
+    normalized_tag="${normalized_tag#.}"
+    if [[ "${normalized_tag}" == "${APP_VERSION}" ]]; then
+        MATCHING_TAG="${head_tag}"
+        break
+    fi
+done <<< "${HEAD_TAGS}"
+
+if [[ -n "${MATCHING_TAG}" ]]; then
+    if [[ "${WORKING_TREE_STATE}" == "clean" ]]; then
         IS_TAGGED_RELEASE=1
     else
-        echo "warning: exact tag '${EXACT_TAG}' matches version.php but the working tree is not clean; including commit hash in package name" >&2
+        echo "warning: tag '${MATCHING_TAG}' matches version.php but the working tree is not clean; including commit hash in package name" >&2
     fi
+elif [[ -n "${HEAD_TAGS}" ]]; then
+    echo "warning: HEAD tags ($(echo ${HEAD_TAGS})) do not match version.php '${APP_VERSION}'; including commit hash in package name" >&2
 fi
 
 if [[ "${IS_TAGGED_RELEASE}" -eq 1 ]]; then

--- a/version.php
+++ b/version.php
@@ -1,3 +1,3 @@
 <?php
 
-return '4.0';
+return '4.0.0';


### PR DESCRIPTION
Release-prep changes for the official **4.0.0** release, kept separate from the bug-fix branch.

## Changes
- **`version.php`**: `4.0` → `4.0.0` (three-part, consistent with the `v.3.0.0` / `v.3.0.1` tag scheme).
- **`docs/release/build-release.sh`**: an official tagged release — `HEAD` on an exact tag whose version matches `version.php`, with a clean working tree — now omits the commit hash from the package name (`ultiorganizer-install-4.0.0.zip`), since the tag already pins the commit. Development and untagged builds still append the short hash for traceability. Tag/version mismatch or a dirty tree falls back to the hashed name with a warning.
- **`docs/deployment.md`**: documents both naming forms and updates the version examples to `4.0.0`.

## Verification
- `bash -n docs/release/build-release.sh` passes.
- Naming decision exercised across untagged, tag+clean, `v4.0.0` alt form, tag+dirty, and tag-mismatch cases.
- Real `--install` build reports `Version: 4.0.0` and contains `index.php`.

## Release flow after merge
1. Merge this PR and the bug-fix branch into `master`; let CI pass.
2. `git switch master && git pull --ff-only` (confirm `version.php` prints `4.0.0`).
3. `git tag -a v.4.0.0 -m "Ultiorganizer 4.0.0"` && `git push origin v.4.0.0`.
4. The Release workflow builds and publishes the GitHub Release with clean-named ZIPs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)