### PR TITLE
Fix Live! season/country compatibility and harden admin access

### DIFF
--- a/live/ultiorganizer-compat.patch
+++ b/live/ultiorganizer-compat.patch
@@ -1,5 +1,10 @@
 --- a/admin.php
 +++ b/admin.php
+@@ -27,2 +27,2 @@
+-        // Validate input - season ID should be alphanumeric only
+-        if (!is_string($seasonId) || !preg_match('/^[a-zA-Z0-9_-]+$/', $seasonId)) {
++        // Validate input - season ID may contain letters, numbers, dots, underscores, and hyphens
++        if (!is_string($seasonId) || !preg_match('/^[a-zA-Z0-9._-]+$/', $seasonId)) {
 @@ -40,38 +40,11 @@
          // Open database connection
          OpenConnection();
@@ -44,6 +49,11 @@
  
          return $count > 0;
      } catch (Exception $e) {
+--- a/api.php
++++ b/api.php
+@@ -81 +81 @@
+-	$seasonId = preg_replace('/[^a-zA-Z0-9]/', '', LIVE_SEASON_ID);
++	$seasonId = preg_replace('/[^a-zA-Z0-9.]/', '', LIVE_SEASON_ID);
 --- a/api/AdminManager.php
 +++ b/api/AdminManager.php
 @@ -158,10 +158,9 @@
@@ -58,8 +68,16 @@
                  $allSeasons[] = [
                      'season_id' => $season['season_id'],
                      'name' => $season['name']
+--- a/api/CacheManager.php
++++ b/api/CacheManager.php
+@@ -23 +23 @@
+-		$seasonId = preg_replace('/[^a-zA-Z0-9]/', '', LIVE_SEASON_ID);
++		$seasonId = preg_replace('/[^a-zA-Z0-9.]/', '', LIVE_SEASON_ID);
 --- a/api/GameManager.php
 +++ b/api/GameManager.php
+@@ -23 +23 @@
+-		$seasonId = preg_replace('/[^a-zA-Z0-9]/', '', LIVE_SEASON_ID);
++		$seasonId = preg_replace('/[^a-zA-Z0-9.]/', '', LIVE_SEASON_ID);
 @@ -43,7 +43,8 @@
  		// First, let's the the game IDs that we're looking for
  		$query = sprintf(
@@ -161,7 +179,24 @@
  		if ($game['game_result']['status'] === 'ongoing') {
 --- a/api/ReferenceData.php
 +++ b/api/ReferenceData.php
-@@ -76,7 +76,7 @@
+@@ -9 +9 @@
+-		$seasonId = preg_replace('/[^a-zA-Z0-9]/', '', LIVE_SEASON_ID);
++		$seasonId = preg_replace('/[^a-zA-Z0-9.]/', '', LIVE_SEASON_ID);
+@@ -21,0 +22,7 @@
++		$seasonTeams = TeamManager::normalizeTeamCountries(SeasonTeams($seasonId));
++		$countries = CountryList(true, true);
++
++		if (in_array(TeamManager::UNKNOWN_COUNTRY['country_id'], array_column($seasonTeams, 'country'), true)) {
++			$countries[] = TeamManager::UNKNOWN_COUNTRY;
++		}
++
+@@ -57 +64 @@
+-			}, SeasonTeams($seasonId)),
++			}, $seasonTeams),
+@@ -62 +69 @@
+-			}, CountryList(true, true)),
++			}, $countries),
+@@ -76,7 +83,7 @@
  		$ref['season']['utcOffset'] = TimeHelper::getTimezoneOffset($ref['season']['timezone']);
  		// Spirit is active and visible
  		$ref['season']['spirit'] = intval($seasonInfo['spiritpoints'] && $seasonInfo['showspiritpoints']);
@@ -183,7 +218,41 @@
  		];
 --- a/api/TeamManager.php
 +++ b/api/TeamManager.php
-@@ -112,12 +112,12 @@
+@@ -6,0 +7,25 @@
++	public const UNKNOWN_COUNTRY = [
++		'country_id' => -1,
++		'name' => 'Unknown',
++		'abbreviation' => 'UNK',
++		'flagfile' => null,
++	];
++
++	public static function normalizeTeamCountries(array $teams): array
++	{
++		$clubCountries = array_column(ClubList(), 'country', 'club_id');
++
++		foreach ($teams as &$team) {
++			if (!empty($team['country'])) {
++				continue;
++			}
++
++			$clubId = isset($team['club']) ? (int) $team['club'] : 0;
++			$team['country'] = !empty($clubCountries[$clubId])
++				? (int) $clubCountries[$clubId]
++				: self::UNKNOWN_COUNTRY['country_id'];
++		}
++		unset($team);
++
++		return $teams;
++	}
++
+@@ -19 +44,2 @@
+-		foreach (SeasonTeams($seasonId) as $team) {
++		$seasonTeams = self::normalizeTeamCountries(SeasonTeams($seasonId));
++		foreach ($seasonTeams as $team) {
+@@ -91 +117 @@
+-		$team = TeamInfo($id);
++		$team = self::normalizeTeamCountries([TeamInfo($id)])[0];
+@@ -112,12 +138,12 @@
  		if ($includeSpiritStats) {
  			$team['spiritstats'] = TeamSpiritStats2($id, false);
  			$team['spirittotal'] = TeamSpiritTotal($id, false);
@@ -199,7 +268,7 @@
  			if ( ! $showSpiritComments ) {
  				foreach($team['spiritgiven'] as &$spirit) {
  					$spirit['comments'] = null;
-@@ -128,7 +128,7 @@
+@@ -128,7 +154,7 @@
  			}
  		}
  

--- a/live/ultiorganizer-compat.patch
+++ b/live/ultiorganizer-compat.patch
@@ -56,7 +56,47 @@
 +	$seasonId = preg_replace('/[^a-zA-Z0-9.]/', '', LIVE_SEASON_ID);
 --- a/api/AdminManager.php
 +++ b/api/AdminManager.php
-@@ -158,10 +158,9 @@
+@@ -125,3 +125,19 @@
+-        // The response should be the hash of the password and challenge
+-        $expectedResponse = hash('sha256', $password . $challenge);
+-        return $expectedResponse === $response;
++        $issuedChallenge = $_SESSION['live_admin_challenge'] ?? null;
++        unset($_SESSION['live_admin_challenge']);
++
++        if (
++            !defined('CONFIG_ADMIN_PASSWORD') ||
++            !is_string($password) ||
++            !is_string($challenge) ||
++            !is_string($response) ||
++            !is_array($issuedChallenge) ||
++            !isset($issuedChallenge['value'], $issuedChallenge['expires']) ||
++            (int) $issuedChallenge['expires'] < time() ||
++            !hash_equals((string) $issuedChallenge['value'], $challenge) ||
++            !hash_equals((string) CONFIG_ADMIN_PASSWORD, $password)
++        ) {
++            return false;
++        }
++
++        $expectedResponse = hash('sha256', CONFIG_ADMIN_PASSWORD . $challenge);
++        return hash_equals($expectedResponse, $response);
+@@ -131 +147 @@
+-     * Generate a time-based challenge for authentication
++     * Generate a one-time challenge for authentication
+@@ -136,6 +152,7 @@
+-        // Use the current minute as part of the challenge
+-        $minute = floor(time() / 60);
+-        // Use a server-specific salt (the config password itself)
+-        $salt = defined('CONFIG_ADMIN_PASSWORD') ? CONFIG_ADMIN_PASSWORD : '';
+-        // Generate a challenge based on the minute and salt
+-        return hash('sha256', $minute . $salt);
++        $challenge = bin2hex(random_bytes(32));
++        $_SESSION['live_admin_challenge'] = [
++            'value' => $challenge,
++            'expires' => time() + 300,
++        ];
++
++        return $challenge;
+@@ -158,10 +175,9 @@
      public function getAvailableSeasons() {
          try {
              // Get all seasons
@@ -73,6 +113,13 @@
 @@ -23 +23 @@
 -		$seasonId = preg_replace('/[^a-zA-Z0-9]/', '', LIVE_SEASON_ID);
 +		$seasonId = preg_replace('/[^a-zA-Z0-9.]/', '', LIVE_SEASON_ID);
+--- a/api/ConfigManager.php
++++ b/api/ConfigManager.php
+@@ -407,2 +407,2 @@
+-                                                   "- Or, set to a PHP file relative to the /live/ directory to restrict access and show that page instead\n" .
+-                                                   "- Example: If set to '/conf/comingsoon.php', visitors will always see /live/conf/comingsoon.php instead of the main site\n" .
++                                                   "- Set to <strong>/conf/comingsoon.php</strong> to restrict access and show the bundled maintenance page\n" .
++                                                   "- Other paths are rejected\n" .
 --- a/api/GameManager.php
 +++ b/api/GameManager.php
 @@ -23 +23 @@
@@ -218,7 +265,7 @@
  		];
 --- a/api/TeamManager.php
 +++ b/api/TeamManager.php
-@@ -6,0 +7,25 @@
+@@ -6,0 +7,26 @@
 +	public const UNKNOWN_COUNTRY = [
 +		'country_id' => -1,
 +		'name' => 'Unknown',
@@ -245,14 +292,14 @@
 +		return $teams;
 +	}
 +
-@@ -19 +44,2 @@
+@@ -19 +45,2 @@
 -		foreach (SeasonTeams($seasonId) as $team) {
 +		$seasonTeams = self::normalizeTeamCountries(SeasonTeams($seasonId));
 +		foreach ($seasonTeams as $team) {
-@@ -91 +117 @@
+@@ -91 +118 @@
 -		$team = TeamInfo($id);
 +		$team = self::normalizeTeamCountries([TeamInfo($id)])[0];
-@@ -112,12 +138,12 @@
+@@ -112,12 +139,12 @@
  		if ($includeSpiritStats) {
  			$team['spiritstats'] = TeamSpiritStats2($id, false);
  			$team['spirittotal'] = TeamSpiritTotal($id, false);
@@ -268,7 +315,7 @@
  			if ( ! $showSpiritComments ) {
  				foreach($team['spiritgiven'] as &$spirit) {
  					$spirit['comments'] = null;
-@@ -128,7 +154,7 @@
+@@ -128,7 +155,7 @@
  			}
  		}
  
@@ -277,3 +324,21 @@
  
  		foreach ($team['players'] as &$player) {
  			$info = PlayerInfo($player['player_id']);
+--- a/enable-live.php
++++ b/enable-live.php
+@@ -19,7 +19,12 @@
+-  if (!isset($_GET['unlock']) || $_GET['unlock'] != 1) {
+-      include __DIR__ . $config['MAINTENANCE_PAGE_PATH'];
+-      die();
++  if (!isset($_GET['unlock']) || $_GET['unlock'] !== '1') {
++      if ($config['MAINTENANCE_PAGE_PATH'] !== '/conf/comingsoon.php') {
++        http_response_code(503);
++        exit('Maintenance mode is misconfigured.');
++      }
++
++      include __DIR__ . '/conf/comingsoon.php';
++      exit;
+   } else {
+       $_SESSION['unlocked'] = true; // Set unlocked to true
+   }
+ }

--- a/live/ultiorganizer-patch.md
+++ b/live/ultiorganizer-patch.md
@@ -31,6 +31,15 @@ versions), so the Live! skin works across both.
 
 ## Changes by file
 
+### `api.php`
+
+- Preserved dots in the season ID used for cache lock keys, allowing Live! to
+  operate with dotted Ultiorganizer season IDs.
+
+### `api/CacheManager.php`
+
+- Preserved dots in the season ID used for cache filenames.
+
 ### `api/AdminManager.php`
 
 - `getAvailableSeasons()`: replaced `while ($season = DBFetchAssoc(Seasons()))` cursor
@@ -39,6 +48,7 @@ versions), so the Live! skin works across both.
 
 ### `api/GameManager.php`
 
+- Preserved dots when sanitizing the season ID used by game queries.
 - `getGames()`: replaced the legacy `uo_game.pool` join with
   `uo_game_pool` using `timetable = 1`, which is the scheduled/original pool
   that `uo_game.pool` used to represent. The game list query still exposes
@@ -62,6 +72,10 @@ versions), so the Live! skin works across both.
 
 ### `api/ReferenceData.php`
 
+- Preserved dots when sanitizing the season ID used by reference-data queries.
+- Normalized team country IDs before building reference data and added an
+  explicit `Unknown` country entry when neither a team nor its club has a
+  country. This keeps the frontend's team and country maps consistent.
 - `getReferenceData()`: `ShowSpiritComments()` now requires a `$seasoninfo` argument.
   Changed to `ShowSpiritComments($seasonInfo)`.
 
@@ -73,6 +87,8 @@ versions), so the Live! skin works across both.
 
 ### `api/TeamManager.php`
 
+- Team list and detail responses now inherit a missing country from the team's
+  club, falling back to the shared `Unknown` country entry when necessary.
 - `getTeamDetail()`: replaced `mysqli_fetch_all(TeamSpiritPointsGiven(...), MYSQLI_ASSOC)`
   with `DBFetchAllAssoc(TeamSpiritPointsGiven(...))`.
 - `getTeamDetail()`: replaced `mysqli_fetch_all(TeamSpiritPointsReceived(...), MYSQLI_ASSOC)`
@@ -87,8 +103,8 @@ versions), so the Live! skin works across both.
 
 - `checkSeasonExists()`: replaced direct `mysqli_prepare` / `mysqli_stmt_bind_param` /
   `mysqli_stmt_execute` / `mysqli_fetch_assoc` block with `DBEscapeString()` +
-  `DBQueryToValue()`. Input is already validated to alphanumeric-only by the regex
-  guard above, so the escaping is sufficient.
+  `DBQueryToValue()`. The validation now accepts dots in addition to letters,
+  numbers, underscores, and hyphens.
 
 ## Changes made in ultiorganizer (your patch notes for the other side)
 

--- a/live/ultiorganizer-patch.md
+++ b/live/ultiorganizer-patch.md
@@ -5,7 +5,7 @@ database access refactoring (removal of direct `mysqli_*` usage from library fun
 
 ## Baseline
 
-These changes apply on top of **Live! by BULA v1.9.16**, available at:
+These changes apply on top of **Live! by BULA v1.9.17**, available at:
 https://github.com/layoutd/live-by-bula
 
 The patch file `ultiorganizer-compat.patch` in this directory contains all changes
@@ -21,6 +21,12 @@ To verify the patch applies cleanly without making changes:
 ```sh
 patch -p1 --dry-run < ultiorganizer-compat.patch
 ```
+
+> **Frontend limitation:** The public Live! release contains hashed, minified
+> JavaScript assets but not the frontend source or build toolchain. Frontend-only
+> fixes, such as changes to team-name rendering, must therefore be made and
+> rebuilt by the Live! maintainer. This compatibility patch intentionally avoids
+> modifying generated JavaScript bundles.
 
 ## Compat strategy
 
@@ -40,8 +46,16 @@ versions), so the Live! skin works across both.
 
 - Preserved dots in the season ID used for cache filenames.
 
+### `api/ConfigManager.php`
+
+- Restricted the maintenance-page setting documentation to the bundled
+  `/conf/comingsoon.php` page; arbitrary paths are rejected at runtime.
+
 ### `api/AdminManager.php`
 
+- `authenticate()` now validates a server-issued, one-time challenge and compares
+  the submitted credentials against the stored admin password with
+  `hash_equals()`. Challenges expire after five minutes and cannot be replayed.
 - `getAvailableSeasons()`: replaced `while ($season = DBFetchAssoc(Seasons()))` cursor
   loop with `foreach (DBFetchAllAssoc(Seasons()) as $season)`. `Seasons()` now returns
   an array in current ultiorganizer; `DBFetchAllAssoc` handles both old and new.
@@ -98,6 +112,12 @@ versions), so the Live! skin works across both.
 - `getTeamDetail()`: replaced `mysqli_fetch_all($players, MYSQLI_ASSOC)` with
   `DBFetchAllAssoc($players)`. `$players` may be a `mysqli_result` or an array
   depending on which code path runs; `DBFetchAllAssoc` handles both.
+
+### `enable-live.php`
+
+- Replaced the configurable file include with an allow-list containing only the
+  bundled maintenance page. Invalid paths fail closed with HTTP 503, preventing
+  path traversal and execution of writable configuration files.
 
 ### `admin.php`
 


### PR DESCRIPTION
## Summary

Updates the Live! by BULA compatibility patch (`live/ultiorganizer-compat.patch`) and its notes to support dotted Ultiorganizer season IDs, consistent team/country data, and hardened admin/maintenance access. Rebases the baseline to **Live! v1.9.17**.

### Season & country compatibility
- Preserve dots in the season ID across `api.php` (cache lock keys), `api/CacheManager.php` (cache filenames), `api/GameManager.php`, `api/ReferenceData.php`, and `admin.php` validation, so Live! works with dotted Ultiorganizer season IDs.
- Normalize team country IDs in `ReferenceData.php` and `TeamManager.php`, inheriting a missing country from the team's club and falling back to a shared `Unknown` country entry, keeping the frontend's team and country maps consistent.

### Admin & maintenance hardening
- `AdminManager::authenticate()` now validates a server-issued, one-time challenge (5-minute expiry, no replay) and compares credentials with `hash_equals()`.
- `enable-live.php` and `ConfigManager.php` restrict the maintenance page to the bundled `/conf/comingsoon.php` via an allow-list; invalid paths fail closed with HTTP 503, preventing path traversal and execution of writable config files.

### Notes
- Documents that the public Live! release ships hashed/minified JS without frontend source, so frontend-only fixes must be rebuilt by the Live! maintainer; this patch intentionally avoids touching generated JS bundles.

## Test plan
- `patch -p1 --dry-run < ultiorganizer-compat.patch` applies cleanly on the Live! v1.9.17 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)