### PR TITLE
Order reservation groups by time

### DIFF
--- a/lib/season.functions.php
+++ b/lib/season.functions.php
@@ -698,10 +698,11 @@ function SeasonReservationgroups($seasonId)
 {
     $query = sprintf(
         "
-		SELECT DISTINCT pr.reservationgroup
+		SELECT pr.reservationgroup
 		FROM uo_reservation pr
 		WHERE pr.season='%s'
-		ORDER BY pr.reservationgroup ASC",
+		GROUP BY pr.reservationgroup
+		ORDER BY MIN(pr.starttime), pr.reservationgroup ASC",
         DBEscapeString($seasonId),
     );
 


### PR DESCRIPTION
## Summary

Order the reservation-management group selector by each group's first reservation start time, with the group name as a tie-breaker. This makes the group links on `admin/reservations` follow the same time-oriented flow as the reservation rows instead of sorting alphabetically.

## Impact

Reservation managers see group filters in schedule order, which matches the page context better and avoids a mismatch with the public schedule ordering discussion.

## Validation

- `php -l lib/season.functions.php`
- `vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php -- lib/season.functions.php`
- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G -- lib/season.functions.php`
- `php docs/ai/review-database-access/scripts/check-db-access.php --changed lib/season.functions.php`
- `git diff --check HEAD~1 HEAD`