### PR TITLE
Bypass persistent query cache in scorekeeper and spiritkeeper

### DIFF
--- a/docs/persistent-cache.md
+++ b/docs/persistent-cache.md
@@ -31,6 +31,25 @@ This cache complements the request-local cache in `lib/cache.functions.php`:
 CLI scripts and background jobs have no `REQUEST_METHOD` and therefore bypass
 the cache.
 
+## Request-scoped bypass
+
+A request can opt out of the persistent cache entirely by calling
+`DisablePersistentCacheForRequest()` once at startup, before the first cacheable
+read. `DBQueryCacheable()` then returns false for every read in that request, so
+all SELECTs go straight to the database.
+
+This exists for **live-entry apps** where any staleness is unacceptable and read
+volume is negligible. `scorekeeper/index.php` and `spiritkeeper/index.php` call
+it immediately after `OpenConnection()`. Both use the Post/Redirect/Get pattern:
+an official submits a score (POST, writes the DB), then the browser follows a
+redirect to a GET that re-renders the same screen. Without the bypass, that GET
+can hit a still-valid cache entry populated by the *previous* GET on the same
+screen (within the TTL window) and show pre-write state — prompting the official
+to re-enter the score. The bypass keeps these reads live; the cache stays active
+for public spectator pages, which is the traffic it was built to offload.
+
+Query with `IsPersistentCacheBypassed()`.
+
 ## Configuration
 
 **SYSTEM_FLAG** (`conf/config.inc.php`):
@@ -75,6 +94,12 @@ CacheForgetPersistent(string $namespace, mixed $key = null): void
 
 // Remove all cache files. Returns file count removed.
 CacheWipePersistent(): int
+
+// Disable the persistent cache for the rest of this request (live-entry apps).
+DisablePersistentCacheForRequest(): void
+
+// Whether the persistent cache has been bypassed for this request.
+IsPersistentCacheBypassed(): bool
 ```
 
 ## Trade-offs

--- a/lib/database.php
+++ b/lib/database.php
@@ -159,6 +159,9 @@ function DBQueryCacheable($query)
     if (!function_exists('CacheRememberFor') || !function_exists('IsPersistentCacheEnabled')) {
         return false;
     }
+    if (!empty($GLOBALS['uo_persistent_cache_bypass'])) {
+        return false;
+    }
     if (!IsPersistentCacheEnabled()) {
         return false;
     }

--- a/lib/persistent-cache.functions.php
+++ b/lib/persistent-cache.functions.php
@@ -6,6 +6,30 @@ denyDirectLibAccess(__FILE__);
 require_once __DIR__ . '/cache.functions.php';
 
 /**
+ * Disable the persistent (cross-request) cache for the remainder of this request.
+ *
+ * Intended for live-entry apps (scorekeeper, spiritkeeper) where any staleness is
+ * unacceptable and read volume is negligible. Call it once at request startup,
+ * before the first cacheable read. Honored by DBQueryCacheable() in database.php.
+ *
+ * @return void
+ */
+function DisablePersistentCacheForRequest()
+{
+    $GLOBALS['uo_persistent_cache_bypass'] = true;
+}
+
+/**
+ * Whether the persistent cache has been bypassed for this request.
+ *
+ * @return bool
+ */
+function IsPersistentCacheBypassed()
+{
+    return !empty($GLOBALS['uo_persistent_cache_bypass']);
+}
+
+/**
  * Return a cross-request cached value, recomputing when missing or expired.
  *
  * Writes are atomic (temp-file + rename). A non-blocking exclusive lock prevents

--- a/scorekeeper/index.php
+++ b/scorekeeper/index.php
@@ -6,6 +6,11 @@ $include_prefix = "../";
 include_once '../lib/database.php';
 OpenConnection();
 
+// Live scorekeeping must always read fresh state; opt this app out of the
+// cross-request query cache so the post-redirect GET after logging a goal
+// never returns a pre-write snapshot (which would prompt a duplicate entry).
+DisablePersistentCacheForRequest();
+
 include_once $include_prefix . 'lib/common.functions.php';
 include_once $include_prefix . 'lib/user.functions.php';
 include_once $include_prefix . 'lib/logging.functions.php';

--- a/spiritkeeper/index.php
+++ b/spiritkeeper/index.php
@@ -3,6 +3,11 @@
 include_once '../lib/database.php';
 OpenConnection();
 
+// Live spirit entry must always read fresh state; opt this app out of the
+// cross-request query cache so a submit-then-view flow never returns a
+// pre-write snapshot.
+DisablePersistentCacheForRequest();
+
 include_once $include_prefix . 'lib/session.functions.php';
 include_once $include_prefix . 'lib/team.functions.php';
 include_once $include_prefix . 'lib/season.functions.php';


### PR DESCRIPTION
## Problem

On-field officials using **scorekeeper** occasionally log the same goal twice. A just-logged score does not appear on the redirected page, so the official re-enters it.

## Root cause

The cross-request query cache wired into the four read helpers in `lib/database.php` caches every eligible `SELECT` during **GET** requests for `PersistentCacheTtlSeconds` (default 5 s). Scorekeeper uses Post/Redirect/Get:

1. Viewing the scoresheet is a **GET** — `GameResult()` / `GameGoals()` SELECTs are written to the 5 s cache.
2. Submitting a goal is a **POST** — writes go straight to the DB (POST bypasses the cache) but do **not** invalidate the cached entries (invalidation is TTL-only).
3. The handler redirects to a **GET**, usually within the 5 s window. That GET re-runs the identical SELECTs and gets the **stale, pre-write** entry from step 1 — the goal is missing.

`spiritkeeper` shares the same POST→redirect→GET pattern and the same latent bug.

## Fix

Add a request-scoped bypass and enable it in the two live-entry routers:

- `DisablePersistentCacheForRequest()` / `IsPersistentCacheBypassed()` in `lib/persistent-cache.functions.php`.
- `DBQueryCacheable()` in `lib/database.php` returns false when the bypass flag is set (single gate all four read helpers funnel through).
- `scorekeeper/index.php` and `spiritkeeper/index.php` call the setter right after `OpenConnection()`, before any cacheable read.

These apps are used by a handful of officials, so skipping the cache costs nothing; public spectator pages keep the cache. Rejected alternatives: per-call `*Uncached` variants (would thread a flag through many `lib/` read functions), per-write invalidation (keys are the raw SQL string, so it means a full wipe on every write), and the global off switch (discards the benefit for spectator pages).

## Verification

- `php -l` clean on all changed files
- PHP-CS-Fixer: no changes
- PHPStan: no errors
- DB-access boundary checker (`--changed`): 0 blocking, 0 legacy
- Docs updated: `docs/persistent-cache.md`

Manual end-to-end (add rapid goals within 5 s and confirm each appears immediately; repeat submit-then-view in spiritkeeper; confirm public pages still render) still recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)