### PR TITLE
Bypass persistent query cache on all login-gated pages

### DIFF
--- a/docs/lib-index.md
+++ b/docs/lib-index.md
@@ -6,7 +6,7 @@ Use this index to find existing shared helpers before adding new utility code or
 
 - `lib/accreditation.functions.php`: player accreditation, license data, acknowledgements, and accreditation logs.
 - `lib/api.functions.php`: API token hashing, lookup, touch, CRUD, and rate limiting.
-- `lib/auth.guard.php`: include-time auth guard that starts the session and redirects anonymous users.
+- `lib/auth.guard.php`: include-time auth guard that starts the session, redirects anonymous users, and opts login-gated requests out of the persistent cache (see `docs/persistent-cache.md`).
 - `lib/cache.functions.php`: request-local cache helpers for repeated deterministic lookups.
 - `lib/persistent-cache.functions.php`: cross-request TTL cache helpers (`CacheRememberFor`, `CacheForgetPersistent`, `CacheWipePersistent`) backed by files under `PERSISTENT_CACHE_DIR`.
 - `lib/club.functions.php`: club CRUD, club-team links, profiles, images, and external URLs.

--- a/docs/persistent-cache.md
+++ b/docs/persistent-cache.md
@@ -38,15 +38,27 @@ A request can opt out of the persistent cache entirely by calling
 read. `DBQueryCacheable()` then returns false for every read in that request, so
 all SELECTs go straight to the database.
 
-This exists for **live-entry apps** where any staleness is unacceptable and read
-volume is negligible. `scorekeeper/index.php` and `spiritkeeper/index.php` call
-it immediately after `OpenConnection()`. Both use the Post/Redirect/Get pattern:
-an official submits a score (POST, writes the DB), then the browser follows a
-redirect to a GET that re-renders the same screen. Without the bypass, that GET
-can hit a still-valid cache entry populated by the *previous* GET on the same
-screen (within the TTL window) and show pre-write state — prompting the official
-to re-enter the score. The bypass keeps these reads live; the cache stays active
-for public spectator pages, which is the traffic it was built to offload.
+**All login-gated surfaces bypass the cache.** `lib/auth.guard.php` calls
+`DisablePersistentCacheForRequest()` before it does anything else, so every page
+behind that guard reads live: `admin/`, `user/`, `mobile/`, `scorekeeper/`,
+`spiritkeeper/`, `result.php`, and the `cust/*` member pages. The guard requires
+`lib/persistent-cache.functions.php` directly because a few callers include it
+before `lib/database.php`.
+
+The reason is the Post/Redirect/Get pattern these pages use: an editor submits a
+form (POST, writes the DB), then the browser follows a redirect to a GET that
+re-renders the same screen. The POST itself is never cached, but that following
+GET can hit a still-valid cache entry populated by the *previous* GET on the same
+screen (within the TTL window) and show pre-write state — prompting the editor to
+re-enter the change. Editing traffic is negligible in volume, so nothing is lost
+by reading live.
+
+`scorekeeper/index.php` and `spiritkeeper/index.php` additionally call the bypass
+right after `OpenConnection()`. Keep those calls: they fire before their auth
+include and so also cover each app's own bootstrap reads.
+
+Public spectator pages do not include the auth guard and keep the cache — that is
+the traffic it was built to offload.
 
 Query with `IsPersistentCacheBypassed()`.
 

--- a/lib/auth.guard.php
+++ b/lib/auth.guard.php
@@ -7,6 +7,15 @@ if (!isset($include_prefix)) {
     $include_prefix = __DIR__ . '/../';
 }
 
+// Login-gated surfaces (admin, user, mobile, scorekeeper, spiritkeeper, result,
+// and the cust/ member pages) mutate data and immediately re-read it, often over
+// Post/Redirect/Get. A GET landing inside the persistent cache TTL would render
+// pre-write state, so opt these requests out entirely. Public spectator pages do
+// not include this guard and keep the cache. Required directly because some
+// callers include this guard before lib/database.php.
+require_once __DIR__ . '/persistent-cache.functions.php';
+DisablePersistentCacheForRequest();
+
 include_once $include_prefix . 'lib/session.functions.php';
 include_once $include_prefix . 'lib/user.functions.php';
 


### PR DESCRIPTION
## Problem

Admin and user pages could render pre-write state after saving. Reported on `admin/seasonpools`.

The persistent query cache serves `GET` + `SELECT` reads with a 5 s TTL. In a Post/Redirect/Get flow the POST itself writes uncached, but the redirect lands on a GET that can hit a cache entry populated by the *previous* GET of the same screen, showing the old values. On seasonpools this is reachable via the gear icon → `admin/addseasonpools` save → redirect back (`admin/addseasonpools.php:127`), and via `admin/seriesgames.php:84`.

This is the same failure #85 fixed for scorekeeper and spiritkeeper.

Browser caching is not involved — `session_start()` already sends `Cache-Control: no-store, no-cache` on every page.

## Change

Move the opt-out into `lib/auth.guard.php`, so every login-gated surface reads live: `admin/`, `user/`, `mobile/`, `result.php`, `scorekeeper/`, `spiritkeeper/`, and the `cust/*` member pages.

One hook rather than a view-prefix check in `index.php`: it can't be sidestepped by an alternate route, and it keeps `admin/`/`user/` prefix knowledge out of a second place.

Public spectator pages do not include the guard and keep the cache — that is the traffic it was built to offload.

**Tradeoff:** read-heavy admin pages now always hit the DB across requests (seasonpools is N+1 per pool — `PoolInfo`, `PoolTeams`, `PoolMovingsToPool`, `CanGenerateGames`). Editing traffic is low volume, so this is the intended trade, and the request-local cache still dedupes within a single request.

## Two details worth a reviewer's eye

**The `require_once` is load-bearing.** `cust/default/players.php`, `cust/slkl/players.php` and `cust/slkl/jasenet.php` include the guard *before* `lib/database.php`, so relying on the function already being loaded would fatal on those paths. `php -l` would not catch it.

**Keep the existing calls in `scorekeeper/index.php` and `spiritkeeper/index.php`.** They fire before the auth include and so also cover each app's own bootstrap reads. Spiritkeeper needs its call regardless of that: `spiritkeeperRequireAuth()` returns early *without* including `auth.guard.php` for `'public'` mode (`login.php`), for `'token'` mode (`submitsotg.php`), and for token holders under `'either'` (`teamgames.php`) — so the entire token submit-then-view flow never reaches the new hook.

## Verification

- `composer check` (PHP-CS-Fixer + PHPStan) — 0 findings
- `check-db-access.php --changed` — clean
- `ultiorganizer-tests` matrix — all 8 cases passed (baseline-default, 6 customizations, config-overrides)
- Curled `?view=admin/seasonpools` and `cust/default/players.php` (the risky load-order path) — clean 302, no fatal

Docs updated: `docs/persistent-cache.md` and the `lib/auth.guard.php` entry in `docs/lib-index.md`.

## Note on scope

Broader than the original report, which was just admin and user pages. The hook covers all login-gated surfaces, on the reasoning that login-gated ≠ spectator traffic. Easy to narrow if that's not wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
