### PR TITLE
[codex] Skip empty persistent cache results

### DIFF
--- a/docs/persistent-cache.md
+++ b/docs/persistent-cache.md
@@ -99,7 +99,13 @@ sufficient for the live-scoring read paths and should be preferred.
 
 ```php
 // Return cached value or compute and store it.
-CacheRememberFor(string $namespace, mixed $key, int $ttlSeconds, callable $resolver): mixed
+CacheRememberFor(
+    string $namespace,
+    mixed $key,
+    int $ttlSeconds,
+    callable $resolver,
+    ?callable $shouldStore = null,
+): mixed
 
 // Delete one cached entry. Pass $key = null to clear the whole namespace.
 CacheForgetPersistent(string $namespace, mixed $key = null): void
@@ -122,9 +128,29 @@ IsPersistentCacheBypassed(): bool
 - **Con:** within a single GET request, a `read → write → read` pattern on the
   same row could return the cached pre-write value. This is rare in GET handlers
   and bounded to the TTL window in any case.
-- **Con:** every distinct SELECT becomes a cache file. Under heavy use the
-  cache directory grows; clean it periodically with `CacheWipePersistent()` or
-  filesystem TTL tooling.
+- **Con:** every distinct SELECT whose result is admitted becomes a cache file.
+  Under heavy use the cache directory grows; clean it periodically with
+  `CacheWipePersistent()` or filesystem TTL tooling.
+
+## Cache admission
+
+The database wrappers that return row data pass a cache-admission callback to
+`CacheRememberFor()`. If one of these queries returns no rows, neither a cache
+file nor a lock file is retained. The value that represents no rows depends on
+the wrapper:
+
+| Wrapper | No-row value |
+| --- | --- |
+| `DBQueryToValue()` | `null` |
+| `DBQueryToRow()` | `null` or `false` |
+| `DBQueryToArray()` | `[]` |
+
+The distinction is based on result rows rather than PHP truthiness. For
+example, a scalar `0`, `"0"`, or empty string returned by an existing row
+remains cacheable. `DBQueryRowCount()` does not use this admission rule: it
+caches the integer `0` as a valid row-count result. For the three row-data
+wrappers, if a previously populated cache entry expires and the same query then
+returns no rows, the stale cache file is removed.
 
 ## Cache key derivation
 

--- a/lib/database.php
+++ b/lib/database.php
@@ -489,6 +489,7 @@ function DBQueryToValue($query, $docasting = false)
             [$query, $docasting],
             0,
             fn() => DBQueryToValueUncached($query, $docasting),
+            static fn($value) => $value !== null,
         );
     }
     return DBQueryToValueUncached($query, $docasting);
@@ -557,6 +558,7 @@ function DBQueryToArray($query, $docasting = false)
             [$query, $docasting],
             0,
             fn() => DBQueryToArrayUncached($query, $docasting),
+            static fn($value) => $value !== [],
         );
     }
     return DBQueryToArrayUncached($query, $docasting);
@@ -683,6 +685,7 @@ function DBQueryToRow($query, $docasting = false)
             [$query, $docasting],
             0,
             fn() => DBQueryToRowUncached($query, $docasting),
+            static fn($value) => $value !== null && $value !== false,
         );
     }
     return DBQueryToRowUncached($query, $docasting);

--- a/lib/persistent-cache.functions.php
+++ b/lib/persistent-cache.functions.php
@@ -48,9 +48,11 @@ function IsPersistentCacheBypassed()
  * @param mixed    $key        Namespace-specific cache key (scalar or array)
  * @param int      $ttlSeconds Seconds until expiry; 0 = use PersistentCacheTtlSeconds setting
  * @param callable $resolver   Computes and returns the fresh value on cache miss
+ * @param callable|null $shouldStore Optional admission callback; receives the resolved value and returns whether
+ *                                   it should be persisted
  * @return mixed
  */
-function CacheRememberFor($namespace, $key, $ttlSeconds, $resolver)
+function CacheRememberFor($namespace, $key, $ttlSeconds, $resolver, $shouldStore = null)
 {
     if (!IsPersistentCacheEnabled()) {
         return $resolver();
@@ -86,7 +88,14 @@ function CacheRememberFor($namespace, $key, $ttlSeconds, $resolver)
         }
 
         $value = $resolver();
-        PersistentCacheWrite($filePath, $value, $ttl);
+        if ($shouldStore === null || $shouldStore($value)) {
+            PersistentCacheWrite($filePath, $value, $ttl);
+        } else {
+            // A previously populated query can become empty. Remove its expired
+            // entry and the per-key lock so empty misses leave no files behind.
+            @unlink($filePath);
+            @unlink($lockFile);
+        }
         flock($lock, LOCK_UN);
         fclose($lock);
         return $value;


### PR DESCRIPTION
## Summary

- add an optional cache-admission callback to the persistent cache helper
- avoid retaining cache and lock files for no-row results from `DBQueryToValue()`, `DBQueryToRow()`, and `DBQueryToArray()`
- remove an expired populated entry when the refreshed query returns no rows
- continue caching valid falsy values, including `DBQueryRowCount()` returning integer `0`
- document the cache-admission behavior and trade-offs

## Root cause

The persistent database cache wrote every cacheable GET `SELECT` result, including results for nonexistent identifiers. Public requests with many distinct invalid parameter values could therefore create many distinct serialized empty-result files and matching lock files.

## Impact

No-row results from the row-data wrappers now leave no persistent cache artifacts, reducing disk and inode growth caused by randomized nonexistent identifiers. Valid values such as scalar `0`, `"0"`, empty strings, and zero row counts remain cacheable.

## Validation

- focused cache-admission behavior script
- `php -l lib/persistent-cache.functions.php`
- `php -l lib/database.php`
- PHP-CS-Fixer on changed PHP files
- PHPStan on changed PHP files
- `php docs/ai/review-database-access/scripts/check-db-access.php --changed`
- `git diff --check`
- delegated grammar and terminology review