### PR TITLE
Isolate sessions between installations sharing a domain

### DIFF
--- a/conf/config.inc.example.php
+++ b/conf/config.inc.example.php
@@ -46,8 +46,11 @@ define('PERSISTENT_CACHE_DIR', '/tmp/ultiorganizer-cache');
  * This is one of several settings that must differ between installations sharing
  * a server, together with MAINTENANCE_RUNTIME_DIR and PERSISTENT_CACHE_DIR. See
  * docs/deployment.md for isolating co-hosted installations.
+ *
+ * When configuring by hand instead of running install.php, replace the suffix
+ * below with a value unique to this installation before enabling the line.
  */
-define('UO_SESSION_NAME', 'UO_SESSID_example1');
+// define('UO_SESSION_NAME', 'UO_SESSID_CHANGE_ME');
 
 /**
  * Site customization and localization defaults.

--- a/conf/config.inc.example.php
+++ b/conf/config.inc.example.php
@@ -34,6 +34,22 @@ define('MAINTENANCE_RUNTIME_DIR', '/tmp/ultiorganizer-maintenance');
 define('PERSISTENT_CACHE_DIR', '/tmp/ultiorganizer-cache');
 
 /**
+ * Session cookie name.
+ *
+ * UO_SESSION_NAME must be unique per installation. Installations sharing a
+ * domain otherwise share one session cookie, so a login on one is picked up by
+ * the other. install.php generates a unique value; installations upgraded from
+ * earlier releases fall back to the legacy 'UO_SESSID' name when the constant is
+ * absent. Only letters, digits, '-' and '_' are accepted, and the value must not
+ * be all digits.
+ *
+ * This is one of several settings that must differ between installations sharing
+ * a server, together with MAINTENANCE_RUNTIME_DIR and PERSISTENT_CACHE_DIR. See
+ * docs/deployment.md for isolating co-hosted installations.
+ */
+define('UO_SESSION_NAME', 'UO_SESSID_example1');
+
+/**
  * Site customization and localization defaults.
  *
  * CUSTOMIZATIONS selects the cust/<id>/ skin and override files. DATE_FORMAT

--- a/docs/configuration-flags.md
+++ b/docs/configuration-flags.md
@@ -13,6 +13,7 @@ Use these exact type names when discussing configuration work:
 - Use when the value is deployment-specific, security-sensitive, or infrastructure-specific.
 - Example: `NO_EMAIL` disables outbound mail at the installation level and makes public self-registration unavailable.
 - Example: `MAINTENANCE_RUNTIME_DIR` points to the writable runtime-state directory used for automatic database-upgrade maintenance files and locks.
+- Example: `UO_SESSION_NAME` sets the session cookie name. It must be unique per installation, because installations sharing a domain otherwise share one session cookie. `install.php` generates a unique value; see `docs/deployment.md` for isolating co-hosted installations.
 
 ## INSTALLATION_SETTING
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -99,6 +99,28 @@ post_max_size = 66M
 
 With Apache mod_php you may instead set `php_value upload_max_filesize 64M` in a vhost or directory `.htaccess`, but do not ship `php_value` directives in the release package: they cause a 500 error under PHP-FPM. If the limits are too low, the importer reports that the uploaded file is too large instead of failing silently. The local development environment configures these limits in `docs/dev/php.dev.ini`.
 
+## Co-hosted installations
+
+Running more than one installation on the same server, such as a test instance next to a production one, needs a few settings to differ between them. `MAINTENANCE_RUNTIME_DIR` and `PERSISTENT_CACHE_DIR` must be distinct so the instances do not share upgrade locks or serve each other's cached pages. `UO_SESSION_NAME` must be distinct so they do not share a session cookie.
+
+### Why the session cookie name is not enough
+
+Session cookie names are scoped per domain, not per directory, so two installations on one domain both receive the cookie named `UO_SESSID`. That is what makes a login on one instance appear on the other. Giving each installation its own `UO_SESSION_NAME` stops that.
+
+It does not, however, isolate the stored session data. PHP's `files` session handler stores each session as `sess_<id>` inside `session.save_path`, and the session name is not part of that key. When two installations share a `save_path`, a session id issued by one can be presented to the other under the other's cookie name, and the second installation reads the first installation's session payload. `session.use_strict_mode` does not prevent this: it only rejects session ids that no session has ever used, and here the id is genuinely present in the shared directory.
+
+Ultiorganizer therefore stamps each session with a fingerprint of the installation that created it, derived from `DB_HOST`, `DB_DATABASE`, `BASEURL` and `UO_SESSION_NAME` (see `startSecureSession()` in `lib/session.functions.php`). A session presented to a different installation is discarded and replaced with a new empty one, so no application code sees the foreign session. This works without any server configuration, which matters on shared hosting where `php.ini` is not available.
+
+### Separating session storage
+
+Where you do control the PHP configuration, give each installation its own session directory as well. In a PHP-FPM pool:
+
+```ini
+php_admin_value[session.save_path] = /var/lib/php/sessions/ultiorganizer-prod
+```
+
+One caveat: on Debian and Ubuntu, PHP ships with `session.gc_probability = 0` and expired sessions are removed by a system cron job or systemd timer that only cleans the *default* session directory. A custom `session.save_path` is not swept by it, so session files accumulate indefinitely unless you either add your own cleanup for that directory or re-enable PHP's probabilistic collector with `session.gc_probability = 1`.
+
 ## Development checkout deployments
 
 Developers can continue to run Ultiorganizer directly from the repository checkout. That layout is useful for local work because it includes documentation, development tooling, and review assets.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -111,6 +111,8 @@ It does not, however, isolate the stored session data. PHP's `files` session han
 
 Ultiorganizer therefore stamps each session with a fingerprint of the installation that created it, derived from `DB_HOST`, `DB_DATABASE`, `BASEURL` and `UO_SESSION_NAME` (see `startSecureSession()` in `lib/session.functions.php`). A session presented to a different installation is discarded and replaced with a new empty one, so no application code sees the foreign session. This works without any server configuration, which matters on shared hosting where `php.ini` is not available.
 
+Because those four values make up the fingerprint, changing any of them on a running installation invalidates existing sessions and signs everyone out. Moving an installation to a new address by editing `BASEURL` is the usual case. This is a one-time re-login, not an error.
+
 ### Separating session storage
 
 Where you do control the PHP configuration, give each installation its own session directory as well. In a PHP-FPM pool:

--- a/install.php
+++ b/install.php
@@ -393,6 +393,9 @@ function configurations()
     $upload_dir = isset($_POST['upload_dir']) ? trim($_POST['upload_dir']) : "images/uploads/";
     $maintenance_runtime_dir = isset($_POST['maintenance_runtime_dir']) ? trim($_POST['maintenance_runtime_dir']) : (defined('MAINTENANCE_RUNTIME_DIR') ? MAINTENANCE_RUNTIME_DIR : installSuggestedMaintenanceRuntimeDir());
     $customization = isset($_POST['customization']) ? trim($_POST['customization']) : "default";
+    // Not asked from the installing user: the value only has to be unique, and an
+    // existing name is kept so re-running the installer does not drop live sessions.
+    $session_name = defined('UO_SESSION_NAME') ? UO_SESSION_NAME : installGeneratedSessionName();
     $baseurl = isset($_POST['baseurl']) ? trim($_POST['baseurl']) : GetURLBase();
     $disable_self_registration = !empty($_POST['disable_self_registration']);
     $disable_email = !empty($_POST['disable_email']);
@@ -482,6 +485,7 @@ function configurations()
             fwrite($fh, "define('BASEURL', '$baseurl');\n");
             fwrite($fh, "define('UPLOAD_DIR', '$upload_dir');\n");
             fwrite($fh, "define('MAINTENANCE_RUNTIME_DIR', '" . addslashes($maintenance_runtime_dir) . "');\n");
+            fwrite($fh, "define('UO_SESSION_NAME', '$session_name');\n");
             fwrite($fh, "define('CUSTOMIZATIONS', '$customization');\n");
             fwrite($fh, "define('DATE_FORMAT', _(\"%d.%m.%Y %H:%M\"));\n");
             fwrite($fh, "define('WORD_DELIMITER', '/([\;\,\-_\s\/\.])/');\n");
@@ -901,6 +905,19 @@ function GetURLBase()
         }
     }
     return $url;
+}
+
+/**
+ * Generate a session cookie name unique to this installation.
+ *
+ * Installations sharing a domain must not share a session cookie name, or a login
+ * on one is picked up by the other.
+ *
+ * @return string
+ */
+function installGeneratedSessionName()
+{
+    return 'UO_SESSID_' . bin2hex(random_bytes(4));
 }
 
 function installSuggestedMaintenanceRuntimeDir()

--- a/lib/session.functions.php
+++ b/lib/session.functions.php
@@ -4,6 +4,92 @@ require_once __DIR__ . '/include_only.guard.php';
 denyDirectLibAccess(__FILE__);
 
 /**
+ * Session key holding the fingerprint of the installation that created the session.
+ */
+define('SESSION_INSTANCE_KEY', '__uo_instance');
+
+/**
+ * Resolve the session cookie name for this installation.
+ *
+ * Installations sharing a domain must not share a session cookie name, or a login
+ * on one instance is picked up by the other. `UO_SESSION_NAME` is written per
+ * installation by `install.php`; the legacy `UO_SESSID` name stays the default so
+ * installations upgraded from earlier versions keep their existing sessions.
+ *
+ * @return string
+ */
+function sessionCookieName()
+{
+    $default = 'UO_SESSID';
+
+    if (!defined('UO_SESSION_NAME')) {
+        return $default;
+    }
+
+    $configured = (string) constant('UO_SESSION_NAME');
+
+    // session_name() only raises a warning for invalid values and then silently
+    // falls back to PHPSESSID, so reject anything PHP would not accept.
+    if ($configured === '' || ctype_digit($configured) || preg_match('/[^A-Za-z0-9_-]/', $configured)) {
+        return $default;
+    }
+
+    return $configured;
+}
+
+/**
+ * Build a stable fingerprint identifying this installation.
+ *
+ * Session payloads are stored under the session id alone, so two installations
+ * sharing a `session.save_path` can read each other's session data even when their
+ * cookie names differ. Two genuinely separate installations differ in at least one
+ * of these values.
+ *
+ * @return string
+ */
+function sessionInstanceFingerprint()
+{
+    $parts = [
+        defined('DB_HOST') ? (string) DB_HOST : '',
+        defined('DB_DATABASE') ? (string) DB_DATABASE : '',
+        defined('BASEURL') ? (string) BASEURL : '',
+        sessionCookieName(),
+    ];
+
+    return substr(hash('sha256', implode('|', $parts)), 0, 32);
+}
+
+/**
+ * Reject session data created by another installation.
+ *
+ * Sessions without a fingerprint are adopted rather than discarded, so deploying
+ * this check does not log out everyone who is currently signed in.
+ *
+ * @return void
+ */
+function enforceSessionInstanceBinding()
+{
+    $fingerprint = sessionInstanceFingerprint();
+    $stored = isset($_SESSION[SESSION_INSTANCE_KEY]) ? $_SESSION[SESSION_INSTANCE_KEY] : null;
+
+    if ($stored === null) {
+        $_SESSION[SESSION_INSTANCE_KEY] = $fingerprint;
+        return;
+    }
+
+    if (is_string($stored) && hash_equals($stored, $fingerprint)) {
+        return;
+    }
+
+    // Abort instead of clearing and writing, so the installation that owns this
+    // session keeps its stored data.
+    session_abort();
+    session_id(session_create_id());
+    session_start();
+    $_SESSION[SESSION_INSTANCE_KEY] = $fingerprint;
+}
+
+/**
  * Start a hardened PHP session with consistent cookie settings.
  */
 function startSecureSession()
@@ -29,8 +115,12 @@ function startSecureSession()
         'samesite' => $samesite,
     ]);
 
-    session_name('UO_SESSID');
+    // Reject attacker-supplied session ids that no session has ever used.
+    ini_set('session.use_strict_mode', '1');
+
+    session_name(sessionCookieName());
     session_start();
+    enforceSessionInstanceBinding();
 }
 
 /**

--- a/lib/session.functions.php
+++ b/lib/session.functions.php
@@ -4,11 +4,6 @@ require_once __DIR__ . '/include_only.guard.php';
 denyDirectLibAccess(__FILE__);
 
 /**
- * Session key holding the fingerprint of the installation that created the session.
- */
-define('SESSION_INSTANCE_KEY', '__uo_instance');
-
-/**
  * Resolve the session cookie name for this installation.
  *
  * Installations sharing a domain must not share a session cookie name, or a login
@@ -70,10 +65,10 @@ function sessionInstanceFingerprint()
 function enforceSessionInstanceBinding()
 {
     $fingerprint = sessionInstanceFingerprint();
-    $stored = isset($_SESSION[SESSION_INSTANCE_KEY]) ? $_SESSION[SESSION_INSTANCE_KEY] : null;
+    $stored = isset($_SESSION['__uo_instance']) ? $_SESSION['__uo_instance'] : null;
 
     if ($stored === null) {
-        $_SESSION[SESSION_INSTANCE_KEY] = $fingerprint;
+        $_SESSION['__uo_instance'] = $fingerprint;
         return;
     }
 
@@ -86,7 +81,7 @@ function enforceSessionInstanceBinding()
     session_abort();
     session_id(session_create_id());
     session_start();
-    $_SESSION[SESSION_INSTANCE_KEY] = $fingerprint;
+    $_SESSION['__uo_instance'] = $fingerprint;
 }
 
 /**


### PR DESCRIPTION
Reported by Bruno Gravato: while setting up a WUCC test instance next to another installation, logging into one instance logs you into the other.

## Cause

`startSecureSession()` hardcoded `session_name('UO_SESSID')`, so every installation on a domain uses the same session cookie name and the browser sends one cookie to both.

Two things made this worse than it looks:

- **The constant was half-merged.** `cust/wfdf/head.php` already reads `UO_SESSION_NAME` to render the red "FOR TESTING ONLY!" banner, but the `session_name()` half of Bruno's fork never landed (f6c6842). An administrator sets the constant, sees the test banner, and reasonably concludes the instance is isolated while it is not.
- **It carries privileges, not just identity.** Roles are cached into the session at login (`SetUserSessionData()`) and never revalidated; `isSuperAdmin()` reads `$_SESSION['userproperties']['userrole']`. A session created against a test database therefore carries its uid and superadmin rights into the other installation.

## Change

**A unique cookie name is necessary but not sufficient.** PHP's `files` handler stores each session as `sess_<id>` and the session name is not part of that key, so two installations sharing a `session.save_path` can still read each other's session payload when an id is replayed under the other cookie name. `session.use_strict_mode` does not prevent it: it only rejects ids that no session has ever used, and here the id genuinely exists in the shared directory.

So this does both:

1. `UO_SESSION_NAME` is honored for the cookie name, with a validity guard — `session_name()` only raises a warning for an invalid value and then silently falls back to `PHPSESSID`. Installations without the constant keep the legacy `UO_SESSID` name and their existing sessions.
2. Each session is stamped with a fingerprint of the installation that created it, derived from `DB_HOST`, `DB_DATABASE`, `BASEURL` and `UO_SESSION_NAME`. A session presented to a different installation is discarded and replaced with an empty one. `session_abort()` is used so the installation that owns the session keeps its stored data. This needs no server configuration, which matters on shared hosting.
3. `session.use_strict_mode` is enabled, which closes unrelated session-fixation vectors.
4. `install.php` generates a unique `UO_SESSION_NAME` so isolation is the default rather than opt-in. It is not asked from the installing user, and an existing value is preserved when the installer is re-run.

Sessions without a fingerprint are **adopted** rather than discarded, so deploying this does not sign out everyone who is currently logged in. Already-shared sessions stay valid until they expire, at most one `session.gc_maxlifetime`.

`UO_SESSION_NAME` is a `SYSTEM_FLAG`: it lives in `conf/config.inc.php`, not in database-backed server configuration.

## Verification

Tested against the real implementation with two configured installations sharing one `session.save_path`:

| Scenario | Result |
| --- | --- |
| Test-instance cookie replayed against the other installation | rejected, `uid=-`, fresh session id |
| Owning installation using its own session | unaffected, session data intact |
| Session written before this change, no fingerprint | adopted, user stays logged in |

Also confirmed that a unique cookie name alone does not isolate stored sessions, and that `session.use_strict_mode=1` does not block the replay.

`composer check` passes. The database-access and playoff-layout checkers pass.

**Harness:** all 8 cases fail on this branch, and identically on `master` — the failures are a pre-existing cap-event cluster (`testGameIsFirstOffenceHomeReturnsNullWhenNoEvent`, `testRssGameFeedRendersCapEventsWithoutTeamAttribution`, `testGameplayEndpointReportsCapEventsAsNeutralWithTarget`, `testGameplayPageRendersBothCapEventsWithTargetAndTime`). I re-ran `baseline-default` on `master` and got the same suite-by-suite result. Unrelated to this change and worth a separate issue. `lint`, `unit` and `crawl` pass on both.

## Note for upgrades

`BASEURL` feeds the fingerprint, so changing it on a running installation invalidates existing sessions and signs everyone out once. This is documented in `docs/deployment.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
