### PR TITLE
Spirit score fixes, schedule spirit column, and access restriction

### DIFF
--- a/cust/default/ultiorganizer.css
+++ b/cust/default/ultiorganizer.css
@@ -213,6 +213,18 @@ table[border="2"] {
 	padding-left: 10px;
 }
 
+/* Spirit score pair shown on the schedule for spirit admins. */
+.game-spirit {
+	color: var(--text-muted);
+	font-weight: bold;
+	white-space: nowrap;
+}
+
+.spirit-missing {
+	color: var(--status-warning);
+	text-decoration: none;
+}
+
 .spirit-controlgroup {
 	display: flex;
 	flex-wrap: nowrap;

--- a/lib/pool.functions.php
+++ b/lib/pool.functions.php
@@ -1287,7 +1287,7 @@ function PoolMovedGames($poolId)
             phome.name AS phometeamname, pvisitor.name AS pvisitorteamname, pool.color, pgame.name AS gamename,
             home.abbreviation AS homeshortname, visitor.abbreviation AS visitorshortname, homec.country_id AS homecountryid,
             homec.name AS homecountry, visitorc.country_id AS visitorcountryid, visitorc.name AS visitorcountry,
-            homec.flagfile AS homeflag, visitorc.flagfile AS visitorflag, s.isinternational
+            homec.flagfile AS homeflag, visitorc.flagfile AS visitorflag, s.isinternational, s.spiritmode
             FROM uo_game_pool gp
             LEFT JOIN uo_game pp ON (gp.game=pp.game_id)
             LEFT JOIN uo_game_pool gpo ON (gpo.game=pp.game_id AND gpo.timetable=1)

--- a/lib/spirit.functions.php
+++ b/lib/spirit.functions.php
@@ -1218,7 +1218,7 @@ function GameSpiritTotalsForGames($gameIds)
 			SUM(CASE WHEN ssc.team_id = g.hometeam THEN ssc.value * sct.factor END) AS homesotg,
 			SUM(CASE WHEN ssc.team_id = g.visitorteam THEN ssc.value * sct.factor END) AS visitorsotg
 		FROM uo_game g
-		INNER JOIN uo_spirit_score ssc ON (ssc.game_id = g.game_id)
+		LEFT JOIN uo_spirit_score ssc ON (ssc.game_id = g.game_id)
 		LEFT JOIN uo_spirit_category sct ON (sct.category_id = ssc.category_id)
 		WHERE g.game_id IN (" . implode(",", array_unique($ids)) . ")
 		GROUP BY g.game_id";

--- a/lib/spirit.functions.php
+++ b/lib/spirit.functions.php
@@ -1149,6 +1149,7 @@ function SpiritToolRowsBySeason($season, $onlyVisible = false)
 			s.name AS division,
 			p.name AS pool,
 			g.time,
+			r.reservationgroup,
 			r.fieldname AS field,
 			IF(ssc.team_id = g.hometeam, th.name, tv.name) AS givenfor,
 			IF(ssc.team_id = g.hometeam, tv.name, th.name) AS givenby,
@@ -1182,7 +1183,7 @@ function SpiritToolRowsBySeason($season, $onlyVisible = false)
 					AND g.forfeit=0
 					%s
 				GROUP BY g.game_id, ssc.team_id, s.series_id, s.name, p.name, g.time,
-					r.fieldname, givenfor, givenby
+					r.reservationgroup, r.fieldname, givenfor, givenby
 			ORDER BY s.series_id ASC, givenfor ASC, g.time ASC",
         DBEscapeString($season),
         $visibilityCondition,
@@ -1320,7 +1321,8 @@ function SpiritToCsv($season, $separator)
     foreach ($rows as $row) {
         $exportRow = [
             "Division" => $row['division'],
-            "Day" => !empty($row['time']) ? substr($row['time'], 0, 10) : "",
+            "FieldGroup" => isset($row['reservationgroup']) ? $row['reservationgroup'] : "",
+            "Date" => !empty($row['time']) ? substr($row['time'], 0, 10) : "",
             "Field" => isset($row['field']) ? $row['field'] : "",
             "Time" => !empty($row['time']) ? substr($row['time'], 11, 5) : "",
             "Pool" => $row['pool'],

--- a/lib/spirit.functions.php
+++ b/lib/spirit.functions.php
@@ -1139,6 +1139,7 @@ function SpiritToolRowsBySeason($season)
 			s.name AS division,
 			p.name AS pool,
 			g.time,
+			r.fieldname AS field,
 			IF(ssc.team_id = g.hometeam, th.name, tv.name) AS givenfor,
 			IF(ssc.team_id = g.hometeam, tv.name, th.name) AS givenby,
 			MAX(CASE WHEN sct.`index` = 1 THEN ssc.value END) AS cat1,
@@ -1163,12 +1164,14 @@ function SpiritToolRowsBySeason($season)
 				(ssc.team_id = g.visitorteam AND uc.type = 6)
 			)
 		)
+		LEFT JOIN uo_reservation r ON (r.id = g.reservation)
 				WHERE s.season='%s'
 					AND g.isongoing=0
 					AND (COALESCE(g.homescore,0)+COALESCE(g.visitorscore,0))>0
 					AND sct.`index` > 0
 					AND g.forfeit=0
-				GROUP BY g.game_id, ssc.team_id, s.series_id, s.name, p.name, g.time, givenfor, givenby
+				GROUP BY g.game_id, ssc.team_id, s.series_id, s.name, p.name, g.time,
+					r.fieldname, givenfor, givenby
 			ORDER BY s.series_id ASC, givenfor ASC, g.time ASC",
         DBEscapeString($season),
     );
@@ -1305,7 +1308,7 @@ function SpiritToCsv($season, $separator)
     foreach ($rows as $row) {
         $exportRow = [
             "Division" => $row['division'],
-            "Day" => isset($row['day']) ? $row['day'] : "",
+            "Day" => !empty($row['time']) ? substr($row['time'], 0, 10) : "",
             "Field" => isset($row['field']) ? $row['field'] : "",
             "Time" => !empty($row['time']) ? substr($row['time'], 11, 5) : "",
             "Pool" => $row['pool'],

--- a/lib/spirit.functions.php
+++ b/lib/spirit.functions.php
@@ -206,12 +206,12 @@ function HasFullGameSpiritEditRight($gameId, $game = null)
         return false;
     }
 
+    // Spirit scores stay with the event's spirit and division admins. Per-game
+    // and per-reservation admins run the scoring desk, which is deliberately
+    // kept separate from spirit reporting.
     $seriesId = GameSeries($gameId);
-    $reservationId = GameReservation($gameId);
 
-    return isset($_SESSION['userproperties']['userrole']['seriesadmin'][$seriesId]) ||
-        isset($_SESSION['userproperties']['userrole']['resgameadmin'][$reservationId]) ||
-        isset($_SESSION['userproperties']['userrole']['gameadmin'][$gameId]);
+    return isset($_SESSION['userproperties']['userrole']['seriesadmin'][$seriesId]);
 }
 
 function HasFullGameSpiritViewRight($gameId, $game = null)

--- a/lib/spirit.functions.php
+++ b/lib/spirit.functions.php
@@ -1191,6 +1191,48 @@ function SpiritToolRowsBySeason($season, $onlyVisible = false)
     return DBQueryToArray($query);
 }
 
+/**
+ * Spirit totals for a set of games, keyed by game id.
+ *
+ * Batched counterpart of the per-game totals in GameResult(), for schedule
+ * listings that would otherwise run one spirit query per row. Each entry holds
+ * `home` and `visitor` totals, null when that team has not submitted.
+ *
+ * @param array $gameIds
+ * @return array
+ */
+function GameSpiritTotalsForGames($gameIds)
+{
+    $ids = [];
+    foreach ($gameIds as $gameId) {
+        $gameId = (int) $gameId;
+        if ($gameId > 0) {
+            $ids[] = $gameId;
+        }
+    }
+    if (empty($ids)) {
+        return [];
+    }
+
+    $query = "SELECT g.game_id,
+			SUM(CASE WHEN ssc.team_id = g.hometeam THEN ssc.value * sct.factor END) AS homesotg,
+			SUM(CASE WHEN ssc.team_id = g.visitorteam THEN ssc.value * sct.factor END) AS visitorsotg
+		FROM uo_game g
+		INNER JOIN uo_spirit_score ssc ON (ssc.game_id = g.game_id)
+		LEFT JOIN uo_spirit_category sct ON (sct.category_id = ssc.category_id)
+		WHERE g.game_id IN (" . implode(",", array_unique($ids)) . ")
+		GROUP BY g.game_id";
+
+    $totals = [];
+    foreach (DBQueryToArray($query) as $row) {
+        $totals[(string) $row['game_id']] = [
+            'home' => isset($row['homesotg']) ? $row['homesotg'] : null,
+            'visitor' => isset($row['visitorsotg']) ? $row['visitorsotg'] : null,
+        ];
+    }
+    return $totals;
+}
+
 function SpiritTimeoutSummaryBySeason($season)
 {
     $query = sprintf(

--- a/lib/spirit.functions.php
+++ b/lib/spirit.functions.php
@@ -1129,8 +1129,18 @@ function SpiritScoreRowsByGameTeam($gameId, $teamId)
     return DBQueryToArray($query);
 }
 
-function SpiritToolRowsBySeason($season)
+/**
+ * Spirit score rows for a whole season.
+ *
+ * @param string $season
+ * @param bool $onlyVisible Restrict to games whose spirit scores are publicly
+ *        visible, honouring the event's "show only on complete" setting. Spirit
+ *        tools run unfiltered so admins can find incomplete submissions.
+ * @return array
+ */
+function SpiritToolRowsBySeason($season, $onlyVisible = false)
 {
+    $visibilityCondition = $onlyVisible ? " AND g.show_spirit=1" : "";
     $query = sprintf(
         "SELECT
 			g.game_id,
@@ -1170,10 +1180,12 @@ function SpiritToolRowsBySeason($season)
 					AND (COALESCE(g.homescore,0)+COALESCE(g.visitorscore,0))>0
 					AND sct.`index` > 0
 					AND g.forfeit=0
+					%s
 				GROUP BY g.game_id, ssc.team_id, s.series_id, s.name, p.name, g.time,
 					r.fieldname, givenfor, givenby
 			ORDER BY s.series_id ASC, givenfor ASC, g.time ASC",
         DBEscapeString($season),
+        $visibilityCondition,
     );
     return DBQueryToArray($query);
 }
@@ -1302,7 +1314,7 @@ function SpiritToCsv($season, $separator)
         die(_("Spirit scores are not visible."));
     }
     $showSpiritComments = ShowSpiritComments($seasoninfo);
-    $rows = SpiritToolRowsBySeason($season);
+    $rows = SpiritToolRowsBySeason($season, !hasSpiritToolsRight($season));
     $result = [];
 
     foreach ($rows as $row) {

--- a/lib/timetable.functions.php
+++ b/lib/timetable.functions.php
@@ -6,6 +6,7 @@ denyDirectLibAccess(__FILE__);
 require_once __DIR__ . '/configuration.functions.php';
 require_once __DIR__ . '/game.functions.php';
 require_once __DIR__ . '/reservation.functions.php';
+require_once __DIR__ . '/spirit.functions.php';
 
 function CollectGameIdsFromResult($games)
 {
@@ -58,6 +59,7 @@ function TournamentView($games, $grouping = true)
     $isTableOpen = false;
     $rss = IsGameRSSEnabled();
     $mediaUrlsByGame = GetMediaUrlListForGames(CollectGameIdsFromResult($games), "live");
+    $spiritTotals = ScheduleSpiritTotals($games);
 
     foreach ($games as $game) {
         $placeLabel = ReservationPlaceText(U_($game['placename']), U_($game['fieldname']));
@@ -109,7 +111,7 @@ function TournamentView($games, $grouping = true)
 
         if ($isTableOpen) {
             //function GameRow($game, $date=false, $time=true, $field=true, $series=false,$pool=false,$info=true)
-            $ret .= GameRow($game, false, true, true, false, false, true, $rss, true, $mediaUrlsByGame);
+            $ret .= GameRow($game, false, true, true, false, false, true, $rss, true, $mediaUrlsByGame, $spiritTotals);
         }
 
         $prevTournament = $game['reservationgroup'];
@@ -140,6 +142,7 @@ function SeriesView($games, $date = true, $time = true)
     $isTableOpen = false;
     $rss = IsGameRSSEnabled();
     $mediaUrlsByGame = GetMediaUrlListForGames(CollectGameIdsFromResult($games), "live");
+    $spiritTotals = ScheduleSpiritTotals($games);
 
     foreach ($games as $game) {
         if (
@@ -165,7 +168,7 @@ function SeriesView($games, $date = true, $time = true)
         }
 
         //function GameRow($game, $date=false, $time=true, $field=true, $series=false,$pool=false,$info=true)
-        $ret .= GameRow($game, $date, $time, true, false, false, true, $rss, true, $mediaUrlsByGame);
+        $ret .= GameRow($game, $date, $time, true, false, false, true, $rss, true, $mediaUrlsByGame, $spiritTotals);
 
         $prevTournament = $game['reservationgroup'];
         $prevPlace = $game['place_id'];
@@ -196,6 +199,7 @@ function PlaceView($games, $grouping = true)
     $isTableOpen = false;
     $rss = IsGameRSSEnabled();
     $mediaUrlsByGame = GetMediaUrlListForGames(CollectGameIdsFromResult($games), "live");
+    $spiritTotals = ScheduleSpiritTotals($games);
 
     foreach ($games as $game) {
         if (
@@ -235,7 +239,7 @@ function PlaceView($games, $grouping = true)
 
         if ($isTableOpen) {
             //function GameRow($game, $date=false, $time=true, $field=true, $series=false,$pool=false,$info=true)
-            $ret .= GameRow($game, false, true, false, true, true, true, $rss, true, $mediaUrlsByGame);
+            $ret .= GameRow($game, false, true, false, true, true, true, $rss, true, $mediaUrlsByGame, $spiritTotals);
         }
 
         $prevTournament = $game['reservationgroup'];
@@ -263,6 +267,7 @@ function TimeView($games, $grouping = true)
     $isTableOpen = false;
     $rss = IsGameRSSEnabled();
     $mediaUrlsByGame = GetMediaUrlListForGames(CollectGameIdsFromResult($games), "live");
+    $spiritTotals = ScheduleSpiritTotals($games);
 
     foreach ($games as $game) {
         if ($game['time'] != $prevTime) {
@@ -278,7 +283,7 @@ function TimeView($games, $grouping = true)
 
         if ($isTableOpen) {
             //function GameRow($game, $date=false, $time=true, $field=true, $series=false,$pool=false,$info=true)
-            $ret .= GameRow($game, false, false, true, true, true, true, $rss, true, $mediaUrlsByGame);
+            $ret .= GameRow($game, false, false, true, true, true, true, $rss, true, $mediaUrlsByGame, $spiritTotals);
         }
 
         $prevTime = $game['time'];
@@ -493,7 +498,54 @@ function SeriesAndPoolHeaders($info)
     return $ret;
 }
 
-function GameRow($game, $date = false, $time = true, $field = true, $series = false, $pool = false, $info = true, $rss = false, $media = true, $mediaUrlsByGame = null)
+/**
+ * Spirit totals for every game in a schedule result, but only for viewers who
+ * administer spirit for the season those games belong to. Returns an empty
+ * array for everyone else, which keeps the spirit column out of public views.
+ *
+ * @param array $games
+ * @return array
+ */
+function ScheduleSpiritTotals($games)
+{
+    if (!$games) {
+        return [];
+    }
+
+    $gameIds = [];
+    foreach ($games as $game) {
+        if (empty($game['game_id']) || empty($game['season'])) {
+            continue;
+        }
+        if (isSpiritAdmin($game['season'])) {
+            $gameIds[] = (int) $game['game_id'];
+        }
+    }
+
+    return GameSpiritTotalsForGames($gameIds);
+}
+
+/**
+ * Spirit score pair for the schedule, e.g. `[13 - 11]`. A team that has not
+ * been scored yet is marked as missing rather than left blank, so a spirit
+ * admin can spot the gaps while scanning the schedule.
+ */
+function GameSpiritView($gameId, $spiritTotals)
+{
+    $gameId = (string) $gameId;
+    if (!isset($spiritTotals[$gameId])) {
+        return "";
+    }
+
+    $missing = "<abbr class='spirit-missing' title='" . _("Spirit score missing") . "'>M</abbr>";
+    $totals = $spiritTotals[$gameId];
+    $home = is_null($totals['home']) ? $missing : (string) (float) $totals['home'];
+    $visitor = is_null($totals['visitor']) ? $missing : (string) (float) $totals['visitor'];
+
+    return "<span class='game-spirit'>[" . $home . " - " . $visitor . "]</span>";
+}
+
+function GameRow($game, $date = false, $time = true, $field = true, $series = false, $pool = false, $info = true, $rss = false, $media = true, $mediaUrlsByGame = null, $spiritTotals = null)
 {
     $datew = 'width:60px';
     $timew = 'width:40px';
@@ -589,7 +641,12 @@ function GameRow($game, $date = false, $time = true, $field = true, $series = fa
             if (!empty($game['forfeit'])) {
                 $ret .= "<td><span class='forfeit-mark'>(" . _("forfeit") . ")</span></td>\n";
             } else {
-                $ret .= "<td></td>\n";
+                // Forfeited games carry no spirit scores, so the cell is free
+                // to show them for spirit admins.
+                if (is_null($spiritTotals)) {
+                    $spiritTotals = ScheduleSpiritTotals([$game]);
+                }
+                $ret .= "<td>" . GameSpiritView($game['game_id'], $spiritTotals) . "</td>\n";
             }
         }
     }

--- a/lib/timetable.functions.php
+++ b/lib/timetable.functions.php
@@ -517,7 +517,7 @@ function ScheduleSpiritTotals($games)
         if (empty($game['game_id']) || empty($game['season'])) {
             continue;
         }
-        if (hasSpiritToolsRight($game['season'])) {
+        if (!empty($game['spiritmode']) && hasSpiritToolsRight($game['season'])) {
             $gameIds[] = (int) $game['game_id'];
         }
     }
@@ -807,7 +807,7 @@ function TimetableGames($id, $gamefilter, $timefilter, $order, $groupfilter = ""
 			phome.name AS phometeamname, pvisitor.name AS pvisitorteamname, pool.color, pgame.name AS gamename,
 			home.abbreviation AS homeshortname, visitor.abbreviation AS visitorshortname, homec.country_id AS homecountryid,
 			homec.name AS homecountry, visitorc.country_id AS visitorcountryid, visitorc.name AS visitorcountry,
-			homec.flagfile AS homeflag, visitorc.flagfile AS visitorflag, s.timezone, s.isinternational
+			homec.flagfile AS homeflag, visitorc.flagfile AS visitorflag, s.timezone, s.isinternational, s.spiritmode
 			FROM uo_game pp
 			INNER JOIN uo_game_pool gp ON (gp.game=pp.game_id AND gp.timetable=1)
 			LEFT JOIN (SELECT COUNT(*) AS goals, game FROM uo_goal GROUP BY game) AS pm ON (pp.game_id=pm.game)

--- a/lib/timetable.functions.php
+++ b/lib/timetable.functions.php
@@ -537,7 +537,7 @@ function GameSpiritView($gameId, $spiritTotals)
         return "";
     }
 
-    $missing = "<abbr class='spirit-missing' title='" . _("Spirit score missing") . "'>M</abbr>";
+    $missing = "<abbr class='spirit-missing' title='" . _("Missing spirit score") . "'>M</abbr>";
     $totals = $spiritTotals[$gameId];
     $home = is_null($totals['home']) ? $missing : (string) (float) $totals['home'];
     $visitor = is_null($totals['visitor']) ? $missing : (string) (float) $totals['visitor'];

--- a/lib/timetable.functions.php
+++ b/lib/timetable.functions.php
@@ -517,7 +517,7 @@ function ScheduleSpiritTotals($games)
         if (empty($game['game_id']) || empty($game['season'])) {
             continue;
         }
-        if (isSpiritAdmin($game['season'])) {
+        if (hasSpiritToolsRight($game['season'])) {
             $gameIds[] = (int) $game['game_id'];
         }
     }
@@ -642,11 +642,10 @@ function GameRow($game, $date = false, $time = true, $field = true, $series = fa
                 $ret .= "<td><span class='forfeit-mark'>(" . _("forfeit") . ")</span></td>\n";
             } else {
                 // Forfeited games carry no spirit scores, so the cell is free
-                // to show them for spirit admins.
-                if (is_null($spiritTotals)) {
-                    $spiritTotals = ScheduleSpiritTotals([$game]);
-                }
-                $ret .= "<td>" . GameSpiritView($game['game_id'], $spiritTotals) . "</td>\n";
+                // to show them for spirit admins. Callers prefetch the totals
+                // for the whole listing; without them the cell stays empty
+                // rather than falling back to a query per row.
+                $ret .= "<td>" . GameSpiritView($game['game_id'], is_array($spiritTotals) ? $spiritTotals : []) . "</td>\n";
             }
         }
     }

--- a/locale/de_DE.utf8/LC_MESSAGES/messages.po
+++ b/locale/de_DE.utf8/LC_MESSAGES/messages.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-11 23:06+0300\n"
+"POT-Creation-Date: 2026-08-13 20:14+0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: stm <stm2@sourceforge.net>\n"
 "Language-Team: Ultiorganizer\n"
@@ -57,7 +57,7 @@ msgstr "%d Übersetzungsschlüssel verfügbar."
 msgid "%d&nbsp;min."
 msgstr "%d&nsbp;min."
 
-#: lib/game.functions.php:798
+#: lib/game.functions.php:800
 #, php-format
 msgid "%s - new point cap %d"
 msgstr "%s - neue Punkteobergrenze %d"
@@ -1638,7 +1638,7 @@ msgstr "Defense-Spielbericht"
 #: admin/seasongames.php:251 user/adddefensesheet.php:11
 #: user/adddefensesheet.php:73 user/addplayerlists.php:285
 #: user/addresult.php:75 user/addscoresheet.php:245 user/addspirit.php:228
-#: user/respgames.php:215
+#: user/respgames.php:216
 msgid "Defence sheet"
 msgstr "Defensebogen"
 
@@ -1976,7 +1976,7 @@ msgstr ""
 #: admin/addtimekeepertemplate.php:12 admin/editstanding.php:17
 #: admin/locations.php:64 admin/locations.php:108 admin/seasonstandings.php:122
 #: admin/seasonstandings.php:548 admin/tdtools.php:93 admin/tdtools.php:101
-#: admin/translations.php:507 user/respgames.php:218
+#: admin/translations.php:507 user/respgames.php:220
 msgid "Edit"
 msgstr "Ändern"
 
@@ -2151,7 +2151,7 @@ msgstr "Gib unten dein neues Passwort ein."
 msgid "Equalization"
 msgstr "Vereinheitlichung"
 
-#: lib/game.functions.php:1100
+#: lib/game.functions.php:1102
 msgid "Erroneous scoresheet number:"
 msgstr "Falsche Spielberichtsnummer:"
 
@@ -2160,11 +2160,11 @@ msgstr "Falsche Spielberichtsnummer:"
 msgid "Error: Could not save result."
 msgstr "Fehler: Konnte Ergebnis nicht speichern"
 
-#: admin/saveschedule.php:168
+#: admin/saveschedule.php:181
 msgid "Error: unknown event."
 msgstr "Fehler: unbekanntes Ereignis."
 
-#: lib/game.functions.php:1984
+#: lib/game.functions.php:1986
 #, php-format
 msgid "Errors: %s."
 msgstr "Fehler: %s."
@@ -2248,7 +2248,7 @@ msgstr "Turnier/Saison erforderlich"
 msgid "Event not found"
 msgstr "Ereignis nicht gefunden"
 
-#: lib/game.functions.php:1112
+#: lib/game.functions.php:1114
 msgid "Event played."
 msgstr "Turnier/Saison beendet."
 
@@ -2404,7 +2404,7 @@ msgstr "Suche Koordinaten"
 #: cust/wfdf/pdfscoresheet.php:280 cust/windmill/pdfscoresheet.php:74
 #: lib/reservation.functions.php:30 lib/reservation.functions.php:36
 #: lib/search.functions.php:303 lib/search.functions.php:377
-#: lib/timetable.functions.php:522 user/adddefensesheet.php:211
+#: lib/timetable.functions.php:574 user/adddefensesheet.php:211
 #: user/addscoresheet.php:546
 msgid "Field"
 msgstr "Feld"
@@ -2712,7 +2712,7 @@ msgstr "Spiel %1$s um %2$s (%3$s) kollidiert mit %4$s um %5$s (%6$s)."
 msgid "Game %1$s at %2$s conflicts with %3$s at %4$s in %5$s."
 msgstr "Spiel %1$s um %2$s kollidiert mit %3$s um %4$s in %5$s."
 
-#: admin/saveschedule.php:82
+#: admin/saveschedule.php:83
 #, php-format
 msgid "Game %s exceeds the reserved end time %s."
 msgstr "Spiel %s ueberschreitet die reservierte Endzeit %s."
@@ -2760,11 +2760,11 @@ msgstr "Das Spiel wurde bereits gespielt. Aktuelles Ergebnis:"
 msgid "Game has ended"
 msgstr "Spiel beendet"
 
-#: lib/game.functions.php:1104
+#: lib/game.functions.php:1106
 msgid "Game has no pool."
 msgstr "Spiel ohne Gruppe."
 
-#: gameplay.php:648 teamcard.php:809 lib/timetable.functions.php:637
+#: gameplay.php:648 teamcard.php:809 lib/timetable.functions.php:694
 msgid "Game history"
 msgstr "Frühere Spiele"
 
@@ -2886,7 +2886,7 @@ msgid "Game statistics"
 msgstr "Spielstatistik"
 
 #: gameplay.php:34 gameplay.php:46 poolstatus.php:860
-#: lib/timetable.functions.php:648 mobile/gameplay.php:15
+#: lib/timetable.functions.php:705 mobile/gameplay.php:15
 #: scorekeeper/gameplay.php:54 user/addscoresheet.php:511
 #: user/respgames.php:200
 msgid "Gameplay"
@@ -3501,7 +3501,7 @@ msgstr "Ungültiges Spiel."
 msgid "Invalid link target."
 msgstr "Ungueltiges Linkziel."
 
-#: install.php:708
+#: install.php:718
 msgid "Invalid password (min. 5, max. 20 characters)."
 msgstr "Ungueltiges Passwort (min. 5, max. 20 Zeichen)."
 
@@ -3727,7 +3727,7 @@ msgstr "Liste der Teams, die einen Durchschnitt von '"
 msgid "Live"
 msgstr "Live"
 
-#: lib/timetable.functions.php:617
+#: lib/timetable.functions.php:674
 msgid "Live Broadcasting"
 msgstr "Live-Übertragung"
 
@@ -3743,7 +3743,7 @@ msgstr "Livestream-URL"
 msgid "Live video"
 msgstr "Live-Video"
 
-#: lib/timetable.functions.php:675
+#: lib/timetable.functions.php:732
 msgid "Local time"
 msgstr "Ortszeit"
 
@@ -3972,12 +3972,17 @@ msgstr ""
 "Fehlende Trikotnummern gefunden! (Klicke auf den Teamnamen, um den Kader zu "
 "bearbeiten)"
 
+#: lib/timetable.functions.php:540
+#, fuzzy
+msgid "Missing spirit score"
+msgstr "Spirit-Bewertung für %s fehlt. "
+
 #: spiritkeeper/editgame.php:76
 #, php-format
 msgid "Missing spirit score for %s. "
 msgstr "Spirit-Bewertung für %s fehlt. "
 
-#: teams.php:446
+#: teams.php:447
 msgid "Missing spirit submissions"
 msgstr "Fehlende Spirit-Einreichungen"
 
@@ -4254,7 +4259,7 @@ msgstr "Keine Spiele"
 msgid "No games to move"
 msgstr "Keine Spiele zum Mitnehmen"
 
-#: lib/game.functions.php:1115
+#: lib/game.functions.php:1117
 msgid "No goals."
 msgstr "Keine Punkte."
 
@@ -4459,7 +4464,7 @@ msgid "One simple score"
 msgstr "Eine einfache Bewertung"
 
 #: poolstatus.php:867 poolstatus.php:869 admin/seasongames.php:190
-#: lib/timetable.functions.php:655 lib/timetable.functions.php:657
+#: lib/timetable.functions.php:712 lib/timetable.functions.php:714
 #: scorekeeper/respgames.php:193
 msgid "Ongoing"
 msgstr "Spiel läuft"
@@ -4804,7 +4809,7 @@ msgstr "Spieler-Statistiken"
 #: admin/seasonstats.php:21 admin/seasonstats.php:35 admin/stats.php:119
 #: admin/tdtools.php:184 mobile/respgames.php:178 user/adddefensesheet.php:64
 #: user/addplayerlists.php:276 user/addresult.php:66 user/addscoresheet.php:236
-#: user/addspirit.php:224 user/respgames.php:206 user/respteams.php:43
+#: user/addspirit.php:224 user/respgames.php:207 user/respteams.php:43
 msgid "Players"
 msgstr "Spieler"
 
@@ -4880,7 +4885,7 @@ msgstr "Punkte"
 msgid "Points for %s must be 0-1000."
 msgstr "Punkte fuer %s muessen zwischen 0 und 1000 liegen."
 
-#: admin/seasonpoints.php:231 lib/game.functions.php:1097
+#: admin/seasonpoints.php:231 lib/game.functions.php:1099
 #: scorekeeper/addresult.php:16 scorekeeper/addresult.php:32
 msgid "Points must be between 0 and 1000."
 msgstr "Punkte muessen zwischen 0 und 1000 liegen."
@@ -4922,7 +4927,7 @@ msgstr "Poolspiele nicht beendet:"
 msgid "Pool is completed:"
 msgstr "Pool ist komplett:"
 
-#: lib/game.functions.php:1107
+#: lib/game.functions.php:1109
 msgid "Pool is locked."
 msgstr "Pool ist gesperrt."
 
@@ -5314,7 +5319,7 @@ msgstr "Wiederherstellen"
 #: user/adddefensesheet.php:63 user/addplayerlists.php:275
 #: user/addresult.php:13 user/addresult.php:27 user/addresult.php:65
 #: user/addscoresheet.php:235 user/addspirit.php:223 user/respgames.php:24
-#: user/respgames.php:205
+#: user/respgames.php:206
 msgid "Result"
 msgstr "Ergebnis"
 
@@ -5330,12 +5335,12 @@ msgstr "Ergebnis nicht gespeichert!"
 msgid "Result saved!"
 msgstr "Ergebnis gespeichert!"
 
-#: lib/game.functions.php:1981
+#: lib/game.functions.php:1983
 #, php-format
 msgid "Results changed: %s."
 msgstr "Ergebnisse geändert: %s."
 
-#: lib/game.functions.php:1978
+#: lib/game.functions.php:1980
 #, php-format
 msgid "Results cleared: %s."
 msgstr "Ergebnisse gelöscht: %s."
@@ -5537,7 +5542,7 @@ msgstr "Samstag"
 #: scorekeeper/addspirittimeouts.php:178 scorekeeper/addtimeouts.php:180
 #: scorekeeper/result.php:101 spiritkeeper/editgame.php:125
 #: user/addmedialink.php:219 user/addplayerlists.php:453 user/addspirit.php:314
-#: user/clubprofile.php:251 user/playerprofile.php:389 user/respgames.php:229
+#: user/clubprofile.php:251 user/playerprofile.php:389 user/respgames.php:230
 #: user/teamplayers.php:279 user/teamprofile.php:191 user/userinfo.php:291
 msgid "Save"
 msgstr "Speichern"
@@ -5601,15 +5606,15 @@ msgstr "Speichern betrifft nur die ausgewählte Division."
 msgid "Schedule"
 msgstr "Spielplan"
 
-#: admin/saveschedule.php:176
+#: admin/saveschedule.php:189
 msgid "Schedule saved and validated."
 msgstr "Spielplan gespeichert und geprüft."
 
-#: admin/saveschedule.php:172
+#: admin/saveschedule.php:185
 msgid "Schedule saved with errors:"
 msgstr "Gespeicherter Zeitplan hat Fehler:"
 
-#: admin/saveschedule.php:174
+#: admin/saveschedule.php:187
 msgid "Schedule saved with warnings:"
 msgstr "Spielplan mit Warnungen gespeichert:"
 
@@ -5740,7 +5745,7 @@ msgstr "Spielstände"
 #: scorekeeper/addscoresheet.php:290 scorekeeper/respgames.php:201
 #: user/adddefensesheet.php:65 user/addplayerlists.php:277
 #: user/addresult.php:67 user/addscoresheet.php:237 user/addspirit.php:225
-#: user/respgames.php:207
+#: user/respgames.php:208
 msgid "Scoresheet"
 msgstr "Spielbericht"
 
@@ -6276,7 +6281,7 @@ msgstr ""
 #: cust/wfdf/pdfscoresheet.php:1121 cust/windmill/pdfscoresheet.php:530
 #: sql/upgrade_db.php:560 user/adddefensesheet.php:69
 #: user/addplayerlists.php:281 user/addresult.php:71 user/addscoresheet.php:241
-#: user/addspirit.php:226 user/respgames.php:211
+#: user/addspirit.php:226 user/respgames.php:212
 msgid "Spirit score"
 msgstr "Spirit-Punktzahl"
 
@@ -6341,7 +6346,7 @@ msgstr "Spirit-Bewertung eingereicht."
 msgid "Spirit scores"
 msgstr "Spirit-Punktzahlen"
 
-#: spiritstatus.php:47 lib/spirit.functions.php:1299
+#: spiritstatus.php:47 lib/spirit.functions.php:1357
 msgid "Spirit scores are not visible."
 msgstr "Spirit-Punktzahlen sind nicht sichtbar."
 
@@ -7025,7 +7030,7 @@ msgstr ""
 "laeuft waehrend Auszeiten nicht an."
 
 #: admin/addseasons.php:423 admin/seasonadmin.php:54
-#: lib/timetable.functions.php:672
+#: lib/timetable.functions.php:729
 msgid "Timezone"
 msgstr "Zeitzone"
 
@@ -7134,7 +7139,7 @@ msgstr "Defenses gesamt"
 msgid "Total number of players:"
 msgstr "Gesamtspielerzahl:"
 
-#: admin/seasonpoints.php:258 lib/game.functions.php:2347
+#: admin/seasonpoints.php:258 lib/game.functions.php:2349
 msgid "Total points"
 msgstr "Gesamtpunkte"
 
@@ -7565,11 +7570,11 @@ msgstr ""
 "koennen nicht eingeplant werden. Bearbeite die Spieldauer oder die Laenge "
 "des Zeitfensters in %s."
 
-#: admin/saveschedule.php:161
+#: admin/saveschedule.php:174
 msgid "Warning: Scheduling conflicts detected based on transfer times."
 msgstr "Warnung: Planungs-Konflikte auf Basis von Wechselzeiten erkannt."
 
-#: admin/saveschedule.php:153
+#: admin/saveschedule.php:166
 msgid "Warning: Scheduling conflicts detected due to overlapping game times."
 msgstr ""
 "Warnung: Planungs-Konflikte aufgrund ueberlappender Spielzeiten erkannt."
@@ -7896,7 +7901,7 @@ msgstr "fuer die Spirit-Eingabe."
 
 #: gamecard.php:167 gameplay.php:117 poolstatus.php:670 poolstatus.php:674
 #: poolstatus.php:853 result.php:71 admin/seasongames.php:234
-#: lib/timetable.functions.php:590
+#: lib/timetable.functions.php:642
 msgid "forfeit"
 msgstr "kampflos"
 
@@ -8247,7 +8252,7 @@ msgstr "update"
 msgid "view"
 msgstr "anzeigen"
 
-#: teams.php:431 admin/poolmoves.php:319
+#: teams.php:432 admin/poolmoves.php:319
 msgid "vs."
 msgstr "gg."
 

--- a/locale/es_ES.utf8/LC_MESSAGES/messages.po
+++ b/locale/es_ES.utf8/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-11 23:06+0300\n"
+"POT-Creation-Date: 2026-08-13 20:14+0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: stm <stm2@sourceforge.net>\n"
 "Language-Team: Ultiorganizer\n"
@@ -58,7 +58,7 @@ msgstr "%d claves de traducción disponibles."
 msgid "%d&nbsp;min."
 msgstr "%d&nbsp;min."
 
-#: lib/game.functions.php:798
+#: lib/game.functions.php:800
 #, php-format
 msgid "%s - new point cap %d"
 msgstr "%s - nuevo límite de puntos %d"
@@ -1651,7 +1651,7 @@ msgstr "Hoja de puntuación de Defensa"
 #: admin/seasongames.php:251 user/adddefensesheet.php:11
 #: user/adddefensesheet.php:73 user/addplayerlists.php:285
 #: user/addresult.php:75 user/addscoresheet.php:245 user/addspirit.php:228
-#: user/respgames.php:215
+#: user/respgames.php:216
 msgid "Defence sheet"
 msgstr "Hoja de defensa"
 
@@ -1988,7 +1988,7 @@ msgstr ""
 #: admin/addtimekeepertemplate.php:12 admin/editstanding.php:17
 #: admin/locations.php:64 admin/locations.php:108 admin/seasonstandings.php:122
 #: admin/seasonstandings.php:548 admin/tdtools.php:93 admin/tdtools.php:101
-#: admin/translations.php:507 user/respgames.php:218
+#: admin/translations.php:507 user/respgames.php:220
 msgid "Edit"
 msgstr "Editar"
 
@@ -2164,7 +2164,7 @@ msgstr "Ingrese su nueva contraseña a continuación."
 msgid "Equalization"
 msgstr "Igualdad"
 
-#: lib/game.functions.php:1100
+#: lib/game.functions.php:1102
 msgid "Erroneous scoresheet number:"
 msgstr "Número de hoja de puntuación erróneo:"
 
@@ -2173,11 +2173,11 @@ msgstr "Número de hoja de puntuación erróneo:"
 msgid "Error: Could not save result."
 msgstr "Error: No se pudo guardar el resultado."
 
-#: admin/saveschedule.php:168
+#: admin/saveschedule.php:181
 msgid "Error: unknown event."
 msgstr "Error: evento desconocido."
 
-#: lib/game.functions.php:1984
+#: lib/game.functions.php:1986
 #, php-format
 msgid "Errors: %s."
 msgstr "Errores: %s."
@@ -2261,7 +2261,7 @@ msgstr "Evento obligatorio"
 msgid "Event not found"
 msgstr "Evento no encontrado"
 
-#: lib/game.functions.php:1112
+#: lib/game.functions.php:1114
 msgid "Event played."
 msgstr "Evento jugado."
 
@@ -2417,7 +2417,7 @@ msgstr "Obtener coordenadas"
 #: cust/wfdf/pdfscoresheet.php:280 cust/windmill/pdfscoresheet.php:74
 #: lib/reservation.functions.php:30 lib/reservation.functions.php:36
 #: lib/search.functions.php:303 lib/search.functions.php:377
-#: lib/timetable.functions.php:522 user/adddefensesheet.php:211
+#: lib/timetable.functions.php:574 user/adddefensesheet.php:211
 #: user/addscoresheet.php:546
 msgid "Field"
 msgstr "Campo"
@@ -2726,7 +2726,7 @@ msgstr ""
 msgid "Game %1$s at %2$s conflicts with %3$s at %4$s in %5$s."
 msgstr "El juego %1$s en %2$s entra en conflicto con %3$s en %4$s en %5$s."
 
-#: admin/saveschedule.php:82
+#: admin/saveschedule.php:83
 #, php-format
 msgid "Game %s exceeds the reserved end time %s."
 msgstr "El juego %s excede el tiempo de finalización reservado %s."
@@ -2774,11 +2774,11 @@ msgstr "El juego ya se ha jugado. Resultado actual:"
 msgid "Game has ended"
 msgstr "El juego ha terminado"
 
-#: lib/game.functions.php:1104
+#: lib/game.functions.php:1106
 msgid "Game has no pool."
 msgstr "El juego no tiene grupo."
 
-#: gameplay.php:648 teamcard.php:809 lib/timetable.functions.php:637
+#: gameplay.php:648 teamcard.php:809 lib/timetable.functions.php:694
 msgid "Game history"
 msgstr "Historial del juego"
 
@@ -2900,7 +2900,7 @@ msgid "Game statistics"
 msgstr "Estadísticas del juego"
 
 #: gameplay.php:34 gameplay.php:46 poolstatus.php:860
-#: lib/timetable.functions.php:648 mobile/gameplay.php:15
+#: lib/timetable.functions.php:705 mobile/gameplay.php:15
 #: scorekeeper/gameplay.php:54 user/addscoresheet.php:511
 #: user/respgames.php:200
 msgid "Gameplay"
@@ -3514,7 +3514,7 @@ msgstr "Juego no válido."
 msgid "Invalid link target."
 msgstr "Destino de enlace no válido."
 
-#: install.php:708
+#: install.php:718
 msgid "Invalid password (min. 5, max. 20 characters)."
 msgstr "Contraseña no válida (mínimo 5, máximo 20 caracteres)."
 
@@ -3739,7 +3739,7 @@ msgstr "Lista de equipos que recibieron un promedio '"
 msgid "Live"
 msgstr "En Vivo"
 
-#: lib/timetable.functions.php:617
+#: lib/timetable.functions.php:674
 msgid "Live Broadcasting"
 msgstr "Transmisión en vivo"
 
@@ -3755,7 +3755,7 @@ msgstr "URL de transmisión en vivo"
 msgid "Live video"
 msgstr "Vídeo en vivo"
 
-#: lib/timetable.functions.php:675
+#: lib/timetable.functions.php:732
 msgid "Local time"
 msgstr "Hora local"
 
@@ -3984,12 +3984,17 @@ msgstr ""
 "¡Se encontraron números de camiseta que faltaban! (haga clic en el nombre "
 "del equipo para editar la lista)"
 
+#: lib/timetable.functions.php:540
+#, fuzzy
+msgid "Missing spirit score"
+msgstr "Falta puntuación de espíritu para %s. "
+
 #: spiritkeeper/editgame.php:76
 #, php-format
 msgid "Missing spirit score for %s. "
 msgstr "Falta puntuación de espíritu para %s. "
 
-#: teams.php:446
+#: teams.php:447
 msgid "Missing spirit submissions"
 msgstr "Envíos de Espíritus faltantes"
 
@@ -4266,7 +4271,7 @@ msgstr "Sin juegos"
 msgid "No games to move"
 msgstr "No hay juegos para mover"
 
-#: lib/game.functions.php:1115
+#: lib/game.functions.php:1117
 msgid "No goals."
 msgstr "Sin goles."
 
@@ -4469,7 +4474,7 @@ msgid "One simple score"
 msgstr "Una puntuación sencilla"
 
 #: poolstatus.php:867 poolstatus.php:869 admin/seasongames.php:190
-#: lib/timetable.functions.php:655 lib/timetable.functions.php:657
+#: lib/timetable.functions.php:712 lib/timetable.functions.php:714
 #: scorekeeper/respgames.php:193
 msgid "Ongoing"
 msgstr "En curso"
@@ -4816,7 +4821,7 @@ msgstr "Estadísticas del jugador"
 #: admin/seasonstats.php:21 admin/seasonstats.php:35 admin/stats.php:119
 #: admin/tdtools.php:184 mobile/respgames.php:178 user/adddefensesheet.php:64
 #: user/addplayerlists.php:276 user/addresult.php:66 user/addscoresheet.php:236
-#: user/addspirit.php:224 user/respgames.php:206 user/respteams.php:43
+#: user/addspirit.php:224 user/respgames.php:207 user/respteams.php:43
 msgid "Players"
 msgstr "Jugadores"
 
@@ -4891,7 +4896,7 @@ msgstr "Puntos"
 msgid "Points for %s must be 0-1000."
 msgstr "Los puntos para %s deben ser 0-1000."
 
-#: admin/seasonpoints.php:231 lib/game.functions.php:1097
+#: admin/seasonpoints.php:231 lib/game.functions.php:1099
 #: scorekeeper/addresult.php:16 scorekeeper/addresult.php:32
 msgid "Points must be between 0 and 1000."
 msgstr "Los puntos deben estar entre 0 y 1000."
@@ -4933,7 +4938,7 @@ msgstr "Juegos de grupo no completados:"
 msgid "Pool is completed:"
 msgstr "El Grupo está completo:"
 
-#: lib/game.functions.php:1107
+#: lib/game.functions.php:1109
 msgid "Pool is locked."
 msgstr "El Grupo está cerrada."
 
@@ -5325,7 +5330,7 @@ msgstr "Restaurar"
 #: user/adddefensesheet.php:63 user/addplayerlists.php:275
 #: user/addresult.php:13 user/addresult.php:27 user/addresult.php:65
 #: user/addscoresheet.php:235 user/addspirit.php:223 user/respgames.php:24
-#: user/respgames.php:205
+#: user/respgames.php:206
 msgid "Result"
 msgstr "Resultado"
 
@@ -5341,12 +5346,12 @@ msgstr "¡Resultado no guardado!"
 msgid "Result saved!"
 msgstr "¡Resultado guardado!"
 
-#: lib/game.functions.php:1981
+#: lib/game.functions.php:1983
 #, php-format
 msgid "Results changed: %s."
 msgstr "Resultados cambiados: %s."
 
-#: lib/game.functions.php:1978
+#: lib/game.functions.php:1980
 #, php-format
 msgid "Results cleared: %s."
 msgstr "Resultados borrados: %s."
@@ -5548,7 +5553,7 @@ msgstr "Sábado"
 #: scorekeeper/addspirittimeouts.php:178 scorekeeper/addtimeouts.php:180
 #: scorekeeper/result.php:101 spiritkeeper/editgame.php:125
 #: user/addmedialink.php:219 user/addplayerlists.php:453 user/addspirit.php:314
-#: user/clubprofile.php:251 user/playerprofile.php:389 user/respgames.php:229
+#: user/clubprofile.php:251 user/playerprofile.php:389 user/respgames.php:230
 #: user/teamplayers.php:279 user/teamprofile.php:191 user/userinfo.php:291
 msgid "Save"
 msgstr "Guardar"
@@ -5612,15 +5617,15 @@ msgstr "El guardado afecta sólo a la división seleccionada."
 msgid "Schedule"
 msgstr "Calendario"
 
-#: admin/saveschedule.php:176
+#: admin/saveschedule.php:189
 msgid "Schedule saved and validated."
 msgstr "Calendario guardado y validado."
 
-#: admin/saveschedule.php:172
+#: admin/saveschedule.php:185
 msgid "Schedule saved with errors:"
 msgstr "Calendario guardado con errores:"
 
-#: admin/saveschedule.php:174
+#: admin/saveschedule.php:187
 msgid "Schedule saved with warnings:"
 msgstr "Calendario guardado con advertencias:"
 
@@ -5751,7 +5756,7 @@ msgstr "Puntajes"
 #: scorekeeper/addscoresheet.php:290 scorekeeper/respgames.php:201
 #: user/adddefensesheet.php:65 user/addplayerlists.php:277
 #: user/addresult.php:67 user/addscoresheet.php:237 user/addspirit.php:225
-#: user/respgames.php:207
+#: user/respgames.php:208
 msgid "Scoresheet"
 msgstr "Hoja de anotación"
 
@@ -6286,7 +6291,7 @@ msgstr ""
 #: cust/wfdf/pdfscoresheet.php:1121 cust/windmill/pdfscoresheet.php:530
 #: sql/upgrade_db.php:560 user/adddefensesheet.php:69
 #: user/addplayerlists.php:281 user/addresult.php:71 user/addscoresheet.php:241
-#: user/addspirit.php:226 user/respgames.php:211
+#: user/addspirit.php:226 user/respgames.php:212
 msgid "Spirit score"
 msgstr "Puntuación de espíritu"
 
@@ -6351,7 +6356,7 @@ msgstr "Puntuación de espíritu enviada."
 msgid "Spirit scores"
 msgstr "Puntuaciones de espíritu"
 
-#: spiritstatus.php:47 lib/spirit.functions.php:1299
+#: spiritstatus.php:47 lib/spirit.functions.php:1357
 msgid "Spirit scores are not visible."
 msgstr "Las puntuaciones de espíritu no son visibles."
 
@@ -7041,7 +7046,7 @@ msgstr ""
 "juego no se detiene durante los tiempos fuera."
 
 #: admin/addseasons.php:423 admin/seasonadmin.php:54
-#: lib/timetable.functions.php:672
+#: lib/timetable.functions.php:729
 msgid "Timezone"
 msgstr "Zona horaria"
 
@@ -7151,7 +7156,7 @@ msgstr "Defensas totales"
 msgid "Total number of players:"
 msgstr "Número total de jugadores:"
 
-#: admin/seasonpoints.php:258 lib/game.functions.php:2347
+#: admin/seasonpoints.php:258 lib/game.functions.php:2349
 msgid "Total points"
 msgstr "Puntos totales"
 
@@ -7583,13 +7588,13 @@ msgstr ""
 "pueden programar. Edite la duración del juego o la duración del intervalo de "
 "tiempo en %s."
 
-#: admin/saveschedule.php:161
+#: admin/saveschedule.php:174
 msgid "Warning: Scheduling conflicts detected based on transfer times."
 msgstr ""
 "Advertencia: Se detectaron conflictos de programación según los tiempos de "
 "transferencia."
 
-#: admin/saveschedule.php:153
+#: admin/saveschedule.php:166
 msgid "Warning: Scheduling conflicts detected due to overlapping game times."
 msgstr ""
 "Advertencia: Se detectaron conflictos de programación debido a la "
@@ -7920,7 +7925,7 @@ msgstr "para la entrada del espíritu."
 
 #: gamecard.php:167 gameplay.php:117 poolstatus.php:670 poolstatus.php:674
 #: poolstatus.php:853 result.php:71 admin/seasongames.php:234
-#: lib/timetable.functions.php:590
+#: lib/timetable.functions.php:642
 msgid "forfeit"
 msgstr "forfeit"
 
@@ -8270,7 +8275,7 @@ msgstr "actualizar"
 msgid "view"
 msgstr "vista"
 
-#: teams.php:431 admin/poolmoves.php:319
+#: teams.php:432 admin/poolmoves.php:319
 msgid "vs."
 msgstr "vs."
 

--- a/locale/fi_FI.utf8/LC_MESSAGES/messages.po
+++ b/locale/fi_FI.utf8/LC_MESSAGES/messages.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-11 23:06+0300\n"
+"POT-Creation-Date: 2026-08-13 20:14+0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: stm <stm2@sourceforge.net>\n"
 "Language-Team: Ultiorganizer\n"
@@ -56,7 +56,7 @@ msgstr "%d käännösavainta saatavilla."
 msgid "%d&nbsp;min."
 msgstr "%d&nbsp;min."
 
-#: lib/game.functions.php:798
+#: lib/game.functions.php:800
 #, php-format
 msgid "%s - new point cap %d"
 msgstr "%s - uusi pistekatto %d"
@@ -1620,7 +1620,7 @@ msgstr "Puolustuspöytäkirja"
 #: admin/seasongames.php:251 user/adddefensesheet.php:11
 #: user/adddefensesheet.php:73 user/addplayerlists.php:285
 #: user/addresult.php:75 user/addscoresheet.php:245 user/addspirit.php:228
-#: user/respgames.php:215
+#: user/respgames.php:216
 msgid "Defence sheet"
 msgstr "Puolustuspöytäkirja"
 
@@ -1955,7 +1955,7 @@ msgstr ""
 #: admin/addtimekeepertemplate.php:12 admin/editstanding.php:17
 #: admin/locations.php:64 admin/locations.php:108 admin/seasonstandings.php:122
 #: admin/seasonstandings.php:548 admin/tdtools.php:93 admin/tdtools.php:101
-#: admin/translations.php:507 user/respgames.php:218
+#: admin/translations.php:507 user/respgames.php:220
 msgid "Edit"
 msgstr "Muokkaa"
 
@@ -2125,7 +2125,7 @@ msgstr "Syötä uusi salasanasi alle."
 msgid "Equalization"
 msgstr "Yhdenmukaistaminen"
 
-#: lib/game.functions.php:1100
+#: lib/game.functions.php:1102
 msgid "Erroneous scoresheet number:"
 msgstr "Virheellinen pöytäkirjan numero:"
 
@@ -2134,11 +2134,11 @@ msgstr "Virheellinen pöytäkirjan numero:"
 msgid "Error: Could not save result."
 msgstr "Virhe: Tuloksia ei voitu tallentaa."
 
-#: admin/saveschedule.php:168
+#: admin/saveschedule.php:181
 msgid "Error: unknown event."
 msgstr "Virhe: tuntematon tapahtuma."
 
-#: lib/game.functions.php:1984
+#: lib/game.functions.php:1986
 #, php-format
 msgid "Errors: %s."
 msgstr "Virheet: %s."
@@ -2222,7 +2222,7 @@ msgstr "Tapahtuman määrittely pakollista"
 msgid "Event not found"
 msgstr "Tapahtumaa ei löydy"
 
-#: lib/game.functions.php:1112
+#: lib/game.functions.php:1114
 msgid "Event played."
 msgstr "Tapahtuma pelattu."
 
@@ -2377,7 +2377,7 @@ msgstr "Hae koordinaatit"
 #: cust/wfdf/pdfscoresheet.php:280 cust/windmill/pdfscoresheet.php:74
 #: lib/reservation.functions.php:30 lib/reservation.functions.php:36
 #: lib/search.functions.php:303 lib/search.functions.php:377
-#: lib/timetable.functions.php:522 user/adddefensesheet.php:211
+#: lib/timetable.functions.php:574 user/adddefensesheet.php:211
 #: user/addscoresheet.php:546
 msgid "Field"
 msgstr "Kenttä"
@@ -2689,7 +2689,7 @@ msgstr ""
 "Ottelu %1$s ajassa %2$s on ristiriidassa ottelun %3$s kanssa ajassa %4$s "
 "paikassa %5$s."
 
-#: admin/saveschedule.php:82
+#: admin/saveschedule.php:83
 #, php-format
 msgid "Game %s exceeds the reserved end time %s."
 msgstr "Ottelu %s ylittää varatun päättymisajan %s."
@@ -2736,11 +2736,11 @@ msgstr "Peli on jo pelattu. Nykyinen tulos:"
 msgid "Game has ended"
 msgstr "Peli on päättynyt"
 
-#: lib/game.functions.php:1104
+#: lib/game.functions.php:1106
 msgid "Game has no pool."
 msgstr "Pelillä ei ole lohkoa."
 
-#: gameplay.php:648 teamcard.php:809 lib/timetable.functions.php:637
+#: gameplay.php:648 teamcard.php:809 lib/timetable.functions.php:694
 msgid "Game history"
 msgstr "Otteluhistoria"
 
@@ -2862,7 +2862,7 @@ msgid "Game statistics"
 msgstr "Pelin tilastot"
 
 #: gameplay.php:34 gameplay.php:46 poolstatus.php:860
-#: lib/timetable.functions.php:648 mobile/gameplay.php:15
+#: lib/timetable.functions.php:705 mobile/gameplay.php:15
 #: scorekeeper/gameplay.php:54 user/addscoresheet.php:511
 #: user/respgames.php:200
 msgid "Gameplay"
@@ -3474,7 +3474,7 @@ msgstr "Virheellinen peli."
 msgid "Invalid link target."
 msgstr "Virheellinen linkkikohde."
 
-#: install.php:708
+#: install.php:718
 msgid "Invalid password (min. 5, max. 20 characters)."
 msgstr "Virheellinen salasana (vähintään 5 ja enintään 20 merkkiä)."
 
@@ -3698,7 +3698,7 @@ msgstr "Luettelo joukkueista, jotka saivat keskiarvon '"
 msgid "Live"
 msgstr "Live"
 
-#: lib/timetable.functions.php:617
+#: lib/timetable.functions.php:674
 msgid "Live Broadcasting"
 msgstr "Suoralähetys"
 
@@ -3714,7 +3714,7 @@ msgstr "Livestriimin URL"
 msgid "Live video"
 msgstr "Live video"
 
-#: lib/timetable.functions.php:675
+#: lib/timetable.functions.php:732
 msgid "Local time"
 msgstr "Paikallisaika"
 
@@ -3942,12 +3942,17 @@ msgstr ""
 "Puuttuvia pelinumeroita löytyi! (muokkaa pelaajalistaa napsauttamalla "
 "joukkueen nimeä)"
 
+#: lib/timetable.functions.php:540
+#, fuzzy
+msgid "Missing spirit score"
+msgstr "Spirit-pisteet puuttuvat joukkueelta %s. "
+
 #: spiritkeeper/editgame.php:76
 #, php-format
 msgid "Missing spirit score for %s. "
 msgstr "Spirit-pisteet puuttuvat joukkueelta %s. "
 
-#: teams.php:446
+#: teams.php:447
 msgid "Missing spirit submissions"
 msgstr "Puuttuvat spirit-arvioinnit"
 
@@ -4224,7 +4229,7 @@ msgstr "Ei pelejä"
 msgid "No games to move"
 msgstr "Ei siirrettäviä pelejä"
 
-#: lib/game.functions.php:1115
+#: lib/game.functions.php:1117
 msgid "No goals."
 msgstr "Ei maaleja."
 
@@ -4426,7 +4431,7 @@ msgid "One simple score"
 msgstr "Yksi yksinkertainen pisteytys"
 
 #: poolstatus.php:867 poolstatus.php:869 admin/seasongames.php:190
-#: lib/timetable.functions.php:655 lib/timetable.functions.php:657
+#: lib/timetable.functions.php:712 lib/timetable.functions.php:714
 #: scorekeeper/respgames.php:193
 msgid "Ongoing"
 msgstr "Kesken"
@@ -4766,7 +4771,7 @@ msgstr "Pelaajatilastot"
 #: admin/seasonstats.php:21 admin/seasonstats.php:35 admin/stats.php:119
 #: admin/tdtools.php:184 mobile/respgames.php:178 user/adddefensesheet.php:64
 #: user/addplayerlists.php:276 user/addresult.php:66 user/addscoresheet.php:236
-#: user/addspirit.php:224 user/respgames.php:206 user/respteams.php:43
+#: user/addspirit.php:224 user/respgames.php:207 user/respteams.php:43
 msgid "Players"
 msgstr "Pelaajat"
 
@@ -4841,7 +4846,7 @@ msgstr "Pisteet"
 msgid "Points for %s must be 0-1000."
 msgstr "Pisteet %s pitää olla väliltä 0-1000."
 
-#: admin/seasonpoints.php:231 lib/game.functions.php:1097
+#: admin/seasonpoints.php:231 lib/game.functions.php:1099
 #: scorekeeper/addresult.php:16 scorekeeper/addresult.php:32
 msgid "Points must be between 0 and 1000."
 msgstr "Pisteet pitää olla väliltä 0 ja 1000."
@@ -4883,7 +4888,7 @@ msgstr "Lohkon pelejä ei olla pelattu:"
 msgid "Pool is completed:"
 msgstr "Lohko on pelattu:"
 
-#: lib/game.functions.php:1107
+#: lib/game.functions.php:1109
 msgid "Pool is locked."
 msgstr "Lohko on lukittu."
 
@@ -5272,7 +5277,7 @@ msgstr "Palauta varmuuskopio"
 #: user/adddefensesheet.php:63 user/addplayerlists.php:275
 #: user/addresult.php:13 user/addresult.php:27 user/addresult.php:65
 #: user/addscoresheet.php:235 user/addspirit.php:223 user/respgames.php:24
-#: user/respgames.php:205
+#: user/respgames.php:206
 msgid "Result"
 msgstr "Tulokset"
 
@@ -5288,12 +5293,12 @@ msgstr "Tulosta ei tallennettu!"
 msgid "Result saved!"
 msgstr "Tulos tallennettu!"
 
-#: lib/game.functions.php:1981
+#: lib/game.functions.php:1983
 #, php-format
 msgid "Results changed: %s."
 msgstr "Uusi tulos: %s."
 
-#: lib/game.functions.php:1978
+#: lib/game.functions.php:1980
 #, php-format
 msgid "Results cleared: %s."
 msgstr "Tulos poistettu: %s."
@@ -5495,7 +5500,7 @@ msgstr "Lauantai"
 #: scorekeeper/addspirittimeouts.php:178 scorekeeper/addtimeouts.php:180
 #: scorekeeper/result.php:101 spiritkeeper/editgame.php:125
 #: user/addmedialink.php:219 user/addplayerlists.php:453 user/addspirit.php:314
-#: user/clubprofile.php:251 user/playerprofile.php:389 user/respgames.php:229
+#: user/clubprofile.php:251 user/playerprofile.php:389 user/respgames.php:230
 #: user/teamplayers.php:279 user/teamprofile.php:191 user/userinfo.php:291
 msgid "Save"
 msgstr "Tallenna"
@@ -5559,15 +5564,15 @@ msgstr "Tallennus vaikuttaa vain valittuun sarjaan."
 msgid "Schedule"
 msgstr "Aikataulu"
 
-#: admin/saveschedule.php:176
+#: admin/saveschedule.php:189
 msgid "Schedule saved and validated."
 msgstr "Aikataulu tallennettu ja tarkistettu."
 
-#: admin/saveschedule.php:172
+#: admin/saveschedule.php:185
 msgid "Schedule saved with errors:"
 msgstr "Aikataulu tallennettu virheineen:"
 
-#: admin/saveschedule.php:174
+#: admin/saveschedule.php:187
 msgid "Schedule saved with warnings:"
 msgstr "Aikataulu tallennettu varoitusten kanssa:"
 
@@ -5698,7 +5703,7 @@ msgstr "Pisteet"
 #: scorekeeper/addscoresheet.php:290 scorekeeper/respgames.php:201
 #: user/adddefensesheet.php:65 user/addplayerlists.php:277
 #: user/addresult.php:67 user/addscoresheet.php:237 user/addspirit.php:225
-#: user/respgames.php:207
+#: user/respgames.php:208
 msgid "Scoresheet"
 msgstr "Pöytäkirja"
 
@@ -6229,7 +6234,7 @@ msgstr ""
 #: cust/wfdf/pdfscoresheet.php:1121 cust/windmill/pdfscoresheet.php:530
 #: sql/upgrade_db.php:560 user/adddefensesheet.php:69
 #: user/addplayerlists.php:281 user/addresult.php:71 user/addscoresheet.php:241
-#: user/addspirit.php:226 user/respgames.php:211
+#: user/addspirit.php:226 user/respgames.php:212
 msgid "Spirit score"
 msgstr "Spirit-piste"
 
@@ -6294,7 +6299,7 @@ msgstr "Spirit-pisteet lähetetty."
 msgid "Spirit scores"
 msgstr "Spirit-pisteet"
 
-#: spiritstatus.php:47 lib/spirit.functions.php:1299
+#: spiritstatus.php:47 lib/spirit.functions.php:1357
 msgid "Spirit scores are not visible."
 msgstr "Spirit-pisteet eivät ole näkyvissä."
 
@@ -6968,7 +6973,7 @@ msgstr ""
 "aikalisien aikana."
 
 #: admin/addseasons.php:423 admin/seasonadmin.php:54
-#: lib/timetable.functions.php:672
+#: lib/timetable.functions.php:729
 msgid "Timezone"
 msgstr "Aikavyöhyke"
 
@@ -7076,7 +7081,7 @@ msgstr "Puolustuksia yhteensä"
 msgid "Total number of players:"
 msgstr "Pelaajia yhteensä:"
 
-#: admin/seasonpoints.php:258 lib/game.functions.php:2347
+#: admin/seasonpoints.php:258 lib/game.functions.php:2349
 msgid "Total points"
 msgstr "Pisteet yhteensä"
 
@@ -7503,11 +7508,11 @@ msgstr ""
 "Varoitus: Löytyi otteluita, joiden kesto on 0 minuuttia. Niitä ei voida "
 "aikatauluttaa. Muokkaa ottelun kestoa tai aikavarauksen pituutta kohdassa %s."
 
-#: admin/saveschedule.php:161
+#: admin/saveschedule.php:174
 msgid "Warning: Scheduling conflicts detected based on transfer times."
 msgstr "Varoitus: Siirtymäaikoihin perustuvia aikatauluristiriitoja havaittu."
 
-#: admin/saveschedule.php:153
+#: admin/saveschedule.php:166
 msgid "Warning: Scheduling conflicts detected due to overlapping game times."
 msgstr ""
 "Varoitus: Päällekkäisistä otteluajoista johtuvia aikatauluristiriitoja "
@@ -7832,7 +7837,7 @@ msgstr "spiritin syöttöä varten."
 
 #: gamecard.php:167 gameplay.php:117 poolstatus.php:670 poolstatus.php:674
 #: poolstatus.php:853 result.php:71 admin/seasongames.php:234
-#: lib/timetable.functions.php:590
+#: lib/timetable.functions.php:642
 msgid "forfeit"
 msgstr "luovutus"
 
@@ -8182,7 +8187,7 @@ msgstr "päivitä"
 msgid "view"
 msgstr "katso"
 
-#: teams.php:431 admin/poolmoves.php:319
+#: teams.php:432 admin/poolmoves.php:319
 msgid "vs."
 msgstr "vs."
 

--- a/poolstatus.php
+++ b/poolstatus.php
@@ -339,14 +339,16 @@ function printSwissdraw($seasoninfo, $poolinfo)
     $ret .= "<table width='100%'>\n";
     if ($poolinfo['mvgames'] == 0 || $poolinfo['mvgames'] == 2) {
         $mvgames = PoolMovedGames($poolinfo['pool_id']);
+        $mvspirit = ScheduleSpiritTotals($mvgames);
         foreach ($mvgames as $game) {
-            $ret .= GameRow($game, false, false, false, false, false, true);
+            $ret .= GameRow($game, false, false, false, false, false, true, false, true, null, $mvspirit);
         }
     }
     $games = TimetableGames($poolinfo['pool_id'], "pool", "all", "series");
+    $spiritTotals = ScheduleSpiritTotals($games);
     foreach ($games as $game) {
         //function GameRow($game, $date=false, $time=true, $field=true, $series=false,$pool=false,$info=true)
-        $ret .= GameRow($game, false, false, false, false, false, true);
+        $ret .= GameRow($game, false, false, false, false, false, true, false, true, null, $spiritTotals);
     }
     $ret .= "</table>\n";
 
@@ -481,14 +483,16 @@ function printRoundRobinPool($seasoninfo, $poolinfo)
     $ret .= "<table width='100%'>\n";
     if ($poolinfo['mvgames'] == 0 || $poolinfo['mvgames'] == 2) {
         $mvgames = PoolMovedGames($poolinfo['pool_id']);
+        $mvspirit = ScheduleSpiritTotals($mvgames);
         foreach ($mvgames as $game) {
-            $ret .= GameRow($game, false, false, false, false, false, true);
+            $ret .= GameRow($game, false, false, false, false, false, true, false, true, null, $mvspirit);
         }
     }
     $games = TimetableGames($poolinfo['pool_id'], "pool", "all", "series");
+    $spiritTotals = ScheduleSpiritTotals($games);
     foreach ($games as $game) {
         //function GameRow($game, $date=false, $time=true, $field=true, $series=false,$pool=false,$info=true)
-        $ret .= GameRow($game, false, false, false, false, false, true);
+        $ret .= GameRow($game, false, false, false, false, false, true, false, true, null, $spiritTotals);
     }
     $ret .= "</table>\n";
 
@@ -559,8 +563,9 @@ function printPlayoffTree($seasoninfo, $poolinfo)
             } else {
                 $notemplate .= "<table width='100%'>\n";
                 $games = TimetableGames($pool['pool_id'], "pool", "all", "series");
+                $spiritTotals = ScheduleSpiritTotals($games);
                 foreach ($games as $game) {
-                    $notemplate .= GameRow($game, false, false, false, false, false, true);
+                    $notemplate .= GameRow($game, false, false, false, false, false, true, false, true, null, $spiritTotals);
                 }
                 $notemplate .= "</table>\n";
             }

--- a/seriesstatus.php
+++ b/seriesstatus.php
@@ -371,8 +371,9 @@ if (ShowSpiritScoresForSeason($seasoninfo)) {
         });
     }
 
-    foreach ($spiritAvg as $teamAvg) {
-        $html .= "<td>" . utf8entities($teamAvg['teamname']) . "</td>";
+    foreach ($spiritAvg as $teamId => $teamAvg) {
+        $html .= "<tr>";
+        $html .= "<td><a href='?view=teamcard&amp;team=" . (int) $teamId . "'>" . utf8entities($teamAvg['teamname']) . "</a></td>";
         $html .= "<td>" . $teamAvg['games'] . "</td>";
         foreach ($categories as $cat) {
             if ($cat['index'] > 0 && isset($teamAvg[$cat['category_id']])) {

--- a/seriesstatus.php
+++ b/seriesstatus.php
@@ -376,12 +376,17 @@ if (ShowSpiritScoresForSeason($seasoninfo)) {
         $html .= "<td><a href='?view=teamcard&amp;team=" . (int) $teamId . "'>" . utf8entities($teamAvg['teamname']) . "</a></td>";
         $html .= "<td>" . $teamAvg['games'] . "</td>";
         foreach ($categories as $cat) {
-            if ($cat['index'] > 0 && isset($teamAvg[$cat['category_id']])) {
-                if ($cat['factor'] != 0) {
-                    $html .= "<td class='center'><b>" . number_format($teamAvg[$cat['category_id']], 2) . "</b></td>";
-                } else {
-                    $html .= "<td class='center'>" . number_format($teamAvg[$cat['category_id']], 2) . "</td>";
-                }
+            if ($cat['index'] <= 0) {
+                continue;
+            }
+            // One cell per scored category, so a team missing a category does
+            // not shift the remaining cells out from under their headers.
+            if (!isset($teamAvg[$cat['category_id']])) {
+                $html .= "<td class='center'>-</td>";
+            } elseif ($cat['factor'] != 0) {
+                $html .= "<td class='center'><b>" . number_format($teamAvg[$cat['category_id']], 2) . "</b></td>";
+            } else {
+                $html .= "<td class='center'>" . number_format($teamAvg[$cat['category_id']], 2) . "</td>";
             }
         }
         $html .= "<td class='center'><b>" . number_format($teamAvg['total'], 2) . "</b></td>";

--- a/spiritstatus.php
+++ b/spiritstatus.php
@@ -57,7 +57,7 @@ foreach ($categories as $cat) {
     }
 }
 
-$spiritAvg = array_values(SeriesSpiritBoard($seriesinfo['series_id']));
+$spiritAvg = SeriesSpiritBoard($seriesinfo['series_id']);
 $spiritTotAvg = SeriesSpiritBoardTotalAverages($seriesinfo['series_id'], false);
 $allowedSorts = ["team", "games", "total"];
 foreach ($scoreCategories as $cat) {
@@ -67,7 +67,7 @@ if (!in_array($spsort, $allowedSorts, true)) {
     $spsort = "total";
 }
 
-usort($spiritAvg, function ($a, $b) use ($spsort) {
+uasort($spiritAvg, function ($a, $b) use ($spsort) {
     if ($spsort === "team") {
         return strcasecmp((string) $a['teamname'], (string) $b['teamname']);
     }
@@ -129,9 +129,9 @@ $html .= "</tr>\n";
 if (empty($spiritAvg)) {
     $html .= "<tr><td colspan='" . (3 + count($scoreCategories)) . "'>" . _("No spirit scores yet.") . "</td></tr>\n";
 } else {
-    foreach ($spiritAvg as $teamAvg) {
+    foreach ($spiritAvg as $teamId => $teamAvg) {
         $html .= "<tr>";
-        $html .= "<td>" . utf8entities($teamAvg['teamname']) . "</td>";
+        $html .= "<td><a href='?view=teamcard&amp;team=" . (int) $teamId . "'>" . utf8entities($teamAvg['teamname']) . "</a></td>";
         $html .= "<td class='center'>" . (isset($teamAvg['games']) ? (int) $teamAvg['games'] : 0) . "</td>";
         foreach ($scoreCategories as $cat) {
             $categoryId = $cat['category_id'];

--- a/teamcard.php
+++ b/teamcard.php
@@ -199,9 +199,10 @@ if ($allgames) {
     $html .= "<h2>" . U_(SeasonName($teaminfo['season'])) . ":</h2>\n";
     $html .=  "<p>" . _("Division") . ": <a href='?view=poolstatus&amp;series=" . $teaminfo['series'] . "'>" . utf8entities(U_($teaminfo['seriesname'])) . "</a></p>";
     $html .= "<table style='width:80%'>\n";
+    $spiritTotals = ScheduleSpiritTotals($allgames);
     foreach ($allgames as $game) {
         //function GameRow($game, $date=false, $time=true, $field=true, $series=false,$pool=false,$info=true)
-        $html .= GameRow($game, false, false, false, false, false, true);
+        $html .= GameRow($game, false, false, false, false, false, true, false, true, null, $spiritTotals);
     }
 
     $html .= "</table>\n";

--- a/teams.php
+++ b/teams.php
@@ -405,12 +405,18 @@ if ($list == "allteams" || $list == "byseeding") {
                 $html .= "<td><a href='?view=teamcard&amp;team=" . (int) $teamId . "'>" . utf8entities($teamAvg['teamname']) . "</a></td>";
                 $html .= "<td>" . $teamAvg['games'] . "</td>";
                 foreach ($categories as $cat) {
-                    if ($cat['index'] > 0 && isset($teamAvg[$cat['category_id']])) {
-                        if ($cat['factor'] != 0) {
-                            $html .= "<td class='center'><b>" . number_format($teamAvg[$cat['category_id']], 2) . "</b></td>";
-                        } else {
-                            $html .= "<td class='center'>" . number_format($teamAvg[$cat['category_id']], 2) . "</td>";
-                        }
+                    if ($cat['index'] <= 0) {
+                        continue;
+                    }
+                    // One cell per scored category, so a team missing a
+                    // category does not shift the remaining cells out from
+                    // under their headers.
+                    if (!isset($teamAvg[$cat['category_id']])) {
+                        $html .= "<td class='center'>-</td>";
+                    } elseif ($cat['factor'] != 0) {
+                        $html .= "<td class='center'><b>" . number_format($teamAvg[$cat['category_id']], 2) . "</b></td>";
+                    } else {
+                        $html .= "<td class='center'>" . number_format($teamAvg[$cat['category_id']], 2) . "</td>";
                     }
                 }
                 $html .= "<td class='center'><b>" . number_format($teamAvg['total'], 2) . "</b></td>";

--- a/teams.php
+++ b/teams.php
@@ -383,7 +383,7 @@ if ($list == "allteams" || $list == "byseeding") {
         foreach ($series as $row) {
             $spiritAvg = SeriesSpiritBoard($row['series_id']);
 
-            usort($spiritAvg, function ($a, $b) {
+            uasort($spiritAvg, function ($a, $b) {
                 // Sort teams by total spirit points in descending order.
                 return $b['total'] <=> $a['total'];
             });
@@ -400,8 +400,9 @@ if ($list == "allteams" || $list == "byseeding") {
             $html .= "</tr>\n";
 
 
-            foreach ($spiritAvg as $teamAvg) {
-                $html .= "<td>" . utf8entities($teamAvg['teamname']) . "</td>";
+            foreach ($spiritAvg as $teamId => $teamAvg) {
+                $html .= "<tr>";
+                $html .= "<td><a href='?view=teamcard&amp;team=" . (int) $teamId . "'>" . utf8entities($teamAvg['teamname']) . "</a></td>";
                 $html .= "<td>" . $teamAvg['games'] . "</td>";
                 foreach ($categories as $cat) {
                     if ($cat['index'] > 0 && isset($teamAvg[$cat['category_id']])) {

--- a/user/respgames.php
+++ b/user/respgames.php
@@ -201,24 +201,25 @@ foreach ($respGameArray as $reservationgroup => $resArray) {
             } else {
                 $html .= "<td></td>";
             }
+            $gamelinks = [];
             if ($game['hometeam'] && $game['visitorteam']) {
-                $html .= "<td class='right nowrap'><a href='?view=user/addresult&amp;game=" . $gameId . "'>" . _("Result") . "</a> | ";
-                $html .= "<a href='?view=user/addplayerlists&amp;game=" . $gameId . "'>" . _("Players") . "</a> | ";
-                $html .= "<a href='?view=user/addscoresheet&amp;game=$gameId'>" . _("Scoresheet") . "</a>";
+                $gamelinks[] = "<a href='?view=user/addresult&amp;game=" . $gameId . "'>" . _("Result") . "</a>";
+                $gamelinks[] = "<a href='?view=user/addplayerlists&amp;game=" . $gameId . "'>" . _("Players") . "</a>";
+                $gamelinks[] = "<a href='?view=user/addscoresheet&amp;game=$gameId'>" . _("Scoresheet") . "</a>";
                 if (!empty($seasoninfo['spiritmode'])) {
                     $spiritUrl = SpiritEntryUrl($gameId);
                     if (!empty($spiritUrl)) {
-                        $html .= " | <a href='" . $spiritUrl . "'>" . _("Spirit score") . "</a>";
+                        $gamelinks[] = "<a href='" . $spiritUrl . "'>" . _("Spirit score") . "</a>";
                     }
                 }
                 if (ShowDefenseStats()) {
-                    $html .= " | <a href='?view=user/adddefensesheet&amp;game=$gameId'>" . _("Defence sheet") . "</a>";
+                    $gamelinks[] = "<a href='?view=user/adddefensesheet&amp;game=$gameId'>" . _("Defence sheet") . "</a>";
                 }
-                if (isSeasonAdmin($seasoninfo['season_id'])) {
-                    $html .= " | <a href='?view=admin/editgame&amp;season=" . $season . "&amp;game=" . $gameId . "'>" . _("Edit") . "</a>";
-                }
-                $html .= "</td>";
             }
+            if (isSeasonAdmin($seasoninfo['season_id'])) {
+                $gamelinks[] = "<a href='?view=admin/editgame&amp;season=" . $season . "&amp;game=" . $gameId . "'>" . _("Edit") . "</a>";
+            }
+            $html .= "<td class='right nowrap'>" . implode(" | ", $gamelinks) . "</td>";
             $html .= "</tr>";
         }
         $html .= "</table>";


### PR DESCRIPTION
Evaluated and reworked a set of externally supplied WJUC patches, rather than taking them as
given. Each item below was assessed for correctness and for whether it belongs upstream, in a
per-event setting, or not at all. Nothing here belongs under `cust/` — the fork-specific items
are policy, not presentation.

## Bug fixes

- **Responsibilities list dropped a table cell.** Games with no teams assigned skipped the
  entire action cell, leaving those rows one cell short and misaligning the table. The cell is
  now always emitted, and the season admin Edit link appears there even before teams are known.
- **Spirit CSV exported two permanently empty columns.** The export read `day` and `field` row
  keys the query never selected. Joins the reservation for the field name and derives the date.
- **Spirit CSV ignored the event's own visibility rules.** `SpiritToolRowsBySeason()` never
  filtered on `show_spirit`, which every on-page spirit view applies, so the public export
  handed out scores the event had chosen to hide — including single-team submissions for events
  configured to publish only once both teams have submitted. On one season in the dev data this
  was 58 of 432 exported rows. The admin spirit tools keep the unfiltered rows, since finding
  incomplete submissions is what they are for.
- **Spirit boards misaligned their category columns.** `seriesstatus.php` and `teams.php`
  emitted a category cell only when the team had a score in it, while the header always emitted
  one per scored category, so a team missing a category shifted every later cell left and its
  total landed under a category heading. Both also emitted spirit rows without an opening `<tr>`,
  collapsing every team onto one row.

## Features

- **Spirit scores on the schedule for spirit admins**, in the forfeit cell — free, because
  forfeited games carry no spirit scores. Teams with no score yet are marked `M` so gaps are
  visible while scanning. Totals are prefetched once per page alongside the media URLs rather
  than queried per row: on a 262-game season that is one query instead of 262, 4 ms instead of
  108 ms. Gated on spirit tools rights, so it is invisible to everyone else.
  Games in an event without spirit scoring are excluded, and a game with no scores at all is
  marked `[M - M]` rather than left blank.
- **Team names link to team cards** on all three spirit boards, which previously rendered them
  as the only plain-text team names in a standings-style table.
- **Field group in the spirit CSV**, and the date column renamed from `Day` to `Date` now that
  it carries an actual date. The rename is safe because the column had only ever exported an
  empty value.

## Behaviour change

**Spirit score access is now restricted to event, spirit, and division admins.** Per-game
(`gameadmin`) and per-reservation (`resgameadmin`) admins no longer get spirit view or edit
rights; those roles staff the scoring desk, and spirit reporting is kept separate from it.

This affects every install, not only events that want it. It reaches the spirit entry links, the
spirit entry and Spiritkeeper pages, spirit comment management, and the submission write paths.
Teams keep access to their own spirit scores through their team edit rights, and the Scorekeeper
app is unaffected (it handles spirit stoppages, not scores).

A per-event setting was considered and deliberately not taken, so this is worth a second opinion
before merge.

## Notes for reviewers

- The reservation columns added to `SpiritToolRowsBySeason()` are listed in `GROUP BY`. Without
  that, the query fails under `ONLY_FULL_GROUP_BY` — the default `sql_mode` on MySQL 5.7 and
  later — with `ERROR 1055`. Verified against a live database both ways.
- The schedule spirit gate is `hasSpiritToolsRight()` rather than the `spiritadmin` role alone,
  so event admins see the column too, consistent with the access restriction above.
- One new user-facing string, `Missing spirit score`, matching existing Spiritkeeper wording.
  Catalogs refreshed. `msgmerge` fuzzy-matched it against `Missing spirit score for %s. ` and
  copied that translation, stray `%s` included; it is flagged `#, fuzzy` so gettext ignores it,
  but a translator un-fuzzying it without editing would ship a literal `%s`.

## Companion change

`ktolonen/ultiorganizer-tests@45b57ea` updates
`SpiritFunctionsLibTest::testHasFullGameSpiritEditRightViaGameAdmin`, which asserted the
behaviour the access restriction removes, and adds the `resgameadmin` case that had no coverage.
Already on `main` there, so the `harness` CI job picks it up.

## Verification

- `composer check` (PHP-CS-Fixer + PHPStan): clean.
- DB access boundary checker: 0 blocking, 0 legacy.
- Test harness `./test:matrix`: all eight cases pass, 1872 integration tests.
- Batched spirit totals cross-checked against `GameResult()` per-team sums: identical.
- Role gating exercised directly: season admin and spirit admin see the column, game admin does
  not, a missing prefetch renders an empty cell.
- Screenshots at desktop width for the spirit boards, the division status page, and the public
  schedule (unchanged for anonymous viewers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
