### PR TITLE
Fix ordinal() suffix for 11th/12th/13th

### DIFF
--- a/lib/common.functions.php
+++ b/lib/common.functions.php
@@ -1309,19 +1309,23 @@ function ordinal($number)
     if (startsWith(GetSessionLocale(), 'en')) {
         // check if we can handle the size of the number
         $ordinal = $number;
-        switch ($number % 10) {
-            case 1:
-                $ordinal .= "st";
-                break;
-            case 2:
-                $ordinal .= "nd";
-                break;
-            case 3:
-                $ordinal .= "rd";
-                break;
-            default:
-                $ordinal .= "th";
-                break;
+        if ($number % 100 >= 11 && $number % 100 <= 13) {
+            $ordinal .= "th";
+        } else {
+            switch ($number % 10) {
+                case 1:
+                    $ordinal .= "st";
+                    break;
+                case 2:
+                    $ordinal .= "nd";
+                    break;
+                case 3:
+                    $ordinal .= "rd";
+                    break;
+                default:
+                    $ordinal .= "th";
+                    break;
+            }
         }
         return $ordinal;
     } else {


### PR DESCRIPTION
## Summary
- The English fallback branch of `ordinal()` (used when PHP's `intl` extension is unavailable — confirmed this is the live path in the dev environment) picked "st"/"nd"/"rd"/"th" purely from the number's last digit, so 11, 12, 13 (and 111, 211, ...) incorrectly got "st"/"nd"/"rd" instead of "th".
- Added a `% 100` check for the 11-13 range before falling through to the last-digit switch.

Reported by Bruno: "I'm guessing it's adding the suffix solely based on the last digit, which doesn't really work for 12th and 13th."

## Test plan
- [x] Verified against the actual fallback branch (no `NumberFormatter` in the dev container) for 1, 2, 3, 4, 11, 12, 13, 21, 22, 23, 101, 111, 112, 113, 121 — 11th/12th/13th/111th/112th/113th now correctly get "th"
- [x] `composer format` / `composer lint` clean on the changed file
- [x] Full harness test matrix passed (49/49 across all cases and suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)