### PR TITLE
Fix playoff round naming for brackets larger than 16 teams

### DIFF
--- a/lib/pool.functions.php
+++ b/lib/pool.functions.php
@@ -2636,10 +2636,10 @@ function GeneratePlayoffPools($poolId, $generate = true)
                 $prevname = "QF";
             } elseif ($rounds - $i == 3) {
                 $name = "Quarterfinals";
-                $prevname = "R1";
+                $prevname = "R" . $i;
             } else {
-                $name = "Round " . ($i);
-                $prevname = "R" . ($i + 1);
+                $name = "Round " . ($i + 1);
+                $prevname = "R" . $i;
             }
 
             if ($generate) {


### PR DESCRIPTION
## Summary
- `GeneratePlayoffPools()` labeled each continuation pool and its incoming scheduling placeholder names using a fixed distance-from-final lookup that implicitly assumed only one preliminary round exists before Quarterfinals. That holds for brackets up to 16 teams but not for 32-team brackets (two preliminary rounds: the master pool and its first follower) or 64-team brackets, so every "Round N" pool name and "R*N* Winner/Loser" scheduling name was off by one for those larger brackets.
- The bracket/tree view (`printPlayoffTree()`) was unaffected since it recomputes round labels from the pool chain's position rather than reading the stored name, but the schedule/game-listing view reads the stored `pool.name` verbatim and showed the wrong round — matching Bruno's report from WUCC.
- This fix is generation-time only: `uo_pool.name` and `uo_moveteams` scheduling names are written once at generation time and are not repaired retroactively for already-generated brackets (e.g. Bruno's WUCC bracket, which he already hand-fixed).

Reported by Bruno during WUCC: pool "I1" in a 32-team playoff showed "Round 1" instead of "Round 2" on the schedule view (bracket/tree view was correct), and games got scheduling names like "R2 Winner/Loser" for what should have been Round 1, and "R1 Winner/Loser" in Quarterfinals where it should have been "R2 Winner/Loser".

## Test plan
- [x] Hand-simulated the exact edited conditional logic for 8/16/32/64-team brackets (`$rounds` = 3/4/5/6): 8 and 16-team output unchanged; 32-team output corrected exactly as reported (`I1` "Round 1"→"Round 2", its incoming names "R2 Winner/Loser"→"R1 Winner/Loser", Quarterfinals' incoming names "R1 Winner/Loser"→"R2 Winner/Loser"); 64-team gets the same class of fix one round earlier
- [x] Grepped for other code paths that might parse these stored round-name/scheduling-name strings back out — none found; they're stored and displayed verbatim
- [x] `docs/ai/review-playoff-layouts/SKILL.md` checker: all layout templates pass, including `32_teams_5_rounds.html` (pre-existing unrelated warning on the odd-team 5-team template)
- [x] `grammar-terminology-reviewer` subagent: clean pass, no new strings introduced
- [x] `composer format` / `composer lint` clean on the changed file
- [x] Full harness test matrix passed (49/49 across all cases and suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)