### PR TITLE
Log unresolved playoff/cross-match pool pairs instead of failing silently

### DIFF
--- a/lib/standings.functions.php
+++ b/lib/standings.functions.php
@@ -74,7 +74,23 @@ function ResolvePlayoffPoolStandings($poolId)
             DBQuery("UPDATE uo_team_pool SET activerank=" . ($i + 2) . " WHERE pool=" . intval($poolId) . " AND team=$teamId1");
         } else {
             //keep current positions
-            LogUnresolvedPoolPairAnomaly($poolId, $teamId1, $teamId2);
+            $anomalyQuery = sprintf(
+                "SELECT COUNT(*) AS total, SUM(isongoing=1) AS ongoing
+					FROM uo_game
+					WHERE ((hometeam=%d AND visitorteam=%d) OR (hometeam=%d AND visitorteam=%d))
+						AND game_id IN (SELECT game FROM uo_game_pool WHERE pool=%d)",
+                (int) $teamId1,
+                (int) $teamId2,
+                (int) $teamId2,
+                (int) $teamId1,
+                (int) $poolId,
+            );
+            $anomalyInfo = DBQueryToRow($anomalyQuery);
+            if ((int) ($anomalyInfo['total'] ?? 0) === 0) {
+                error_log("Pool standings: pool $poolId compared teams $teamId1 and $teamId2 by seed order but found no game between them in this pool; activerank left at its previous value. Check uo_team_pool.rank for duplicate or incorrect values.");
+            } elseif ((int) ($anomalyInfo['ongoing'] ?? 0) > 0) {
+                error_log("Pool standings: pool $poolId teams $teamId1 and $teamId2 have a game still marked ongoing; activerank left at its previous value until the game is finalized.");
+            }
         }
         //check if teams can be moved to next round
         $gamesleft1 = TeamPoolGamesLeft($teamId1, $poolId);
@@ -95,32 +111,6 @@ function ResolvePlayoffPoolStandings($poolId)
 
     //check if there are special ranking rules and apply them
     CheckSpecialRanking($poolId);
-}
-
-/**
- * Log why a compared pair's activerank was left at its previous value:
- * no game between them at all, or a game still marked ongoing.
- */
-function LogUnresolvedPoolPairAnomaly($poolId, $teamId1, $teamId2)
-{
-    // Deliberately no hasstarted filter: an unplayed pair still counts as "a game exists".
-    $query = sprintf(
-        "SELECT COUNT(*) AS total, SUM(isongoing=1) AS ongoing
-			FROM uo_game
-			WHERE ((hometeam=%d AND visitorteam=%d) OR (hometeam=%d AND visitorteam=%d))
-				AND game_id IN (SELECT game FROM uo_game_pool WHERE pool=%d)",
-        (int) $teamId1,
-        (int) $teamId2,
-        (int) $teamId2,
-        (int) $teamId1,
-        (int) $poolId,
-    );
-    $info = DBQueryToRow($query);
-    if ((int) ($info['total'] ?? 0) === 0) {
-        error_log("Pool standings: pool $poolId compared teams $teamId1 and $teamId2 by seed order but found no game between them in this pool; activerank left at its previous value. Check uo_team_pool.rank for duplicate or incorrect values.");
-    } elseif ((int) ($info['ongoing'] ?? 0) > 0) {
-        error_log("Pool standings: pool $poolId teams $teamId1 and $teamId2 have a game still marked ongoing; activerank left at its previous value until the game is finalized.");
-    }
 }
 
 function CheckSpecialRanking($poolId)
@@ -193,7 +183,23 @@ function ResolveCrossMatchPoolStandings($poolId)
             DBQuery("UPDATE uo_team_pool SET activerank=" . ($i + 2) . " WHERE pool=" . intval($poolId) . " AND team=$teamId1");
         } else {
             //keep current positions
-            LogUnresolvedPoolPairAnomaly($poolId, $teamId1, $teamId2);
+            $anomalyQuery = sprintf(
+                "SELECT COUNT(*) AS total, SUM(isongoing=1) AS ongoing
+					FROM uo_game
+					WHERE ((hometeam=%d AND visitorteam=%d) OR (hometeam=%d AND visitorteam=%d))
+						AND game_id IN (SELECT game FROM uo_game_pool WHERE pool=%d)",
+                (int) $teamId1,
+                (int) $teamId2,
+                (int) $teamId2,
+                (int) $teamId1,
+                (int) $poolId,
+            );
+            $anomalyInfo = DBQueryToRow($anomalyQuery);
+            if ((int) ($anomalyInfo['total'] ?? 0) === 0) {
+                error_log("Pool standings: pool $poolId compared teams $teamId1 and $teamId2 by seed order but found no game between them in this pool; activerank left at its previous value. Check uo_team_pool.rank for duplicate or incorrect values.");
+            } elseif ((int) ($anomalyInfo['ongoing'] ?? 0) > 0) {
+                error_log("Pool standings: pool $poolId teams $teamId1 and $teamId2 have a game still marked ongoing; activerank left at its previous value until the game is finalized.");
+            }
         }
         //check if teams can be moved to next round
         $gamesleft1 = TeamPoolGamesLeft($teamId1, $poolId);

--- a/lib/standings.functions.php
+++ b/lib/standings.functions.php
@@ -98,28 +98,12 @@ function ResolvePlayoffPoolStandings($poolId)
 }
 
 /**
- * Diagnose why a playoff/cross-match pair's activerank was left unchanged.
- *
- * The pair-by-pair resolvers keep the current position whenever the two
- * compared teams have no net decisive wins between them. That is correct
- * for a genuine tied score, but the same code path is silently hit when
- * the two teams paired by seed order never actually played each other
- * (e.g. a duplicate or otherwise incorrect uo_team_pool.rank), in which
- * case the displayed standing is left at the pre-game seed instead of
- * reflecting the real result. Log the two anomalous cases so they show
- * up in the PHP error log instead of only as a silently wrong bracket.
- *
- * @param int $poolId
- * @param int $teamId1
- * @param int $teamId2
- * @return void
+ * Log why a compared pair's activerank was left at its previous value:
+ * no game between them at all, or a game still marked ongoing.
  */
 function LogUnresolvedPoolPairAnomaly($poolId, $teamId1, $teamId2)
 {
-    // No hasstarted filter here: a scheduled-but-not-yet-played sibling
-    // pair is a normal, frequent state (every other pair in a multi-match
-    // pool hits this same branch each time one pair's game is resolved),
-    // so it must count as "a game exists" and stay unlogged.
+    // Deliberately no hasstarted filter: an unplayed pair still counts as "a game exists".
     $query = sprintf(
         "SELECT COUNT(*) AS total, SUM(isongoing=1) AS ongoing
 			FROM uo_game

--- a/lib/standings.functions.php
+++ b/lib/standings.functions.php
@@ -27,10 +27,10 @@ function ResolvePlayoffPoolStandings($poolId)
     //query pool teams
     $query = sprintf(
         "
-		SELECT j.team_id, js.activerank 
-		FROM uo_team AS j INNER JOIN uo_team_pool AS js ON (j.team_id = js.team) 
-		WHERE js.pool=%d 
-		ORDER BY js.rank ASC",
+		SELECT j.team_id, js.activerank
+		FROM uo_team AS j INNER JOIN uo_team_pool AS js ON (j.team_id = js.team)
+		WHERE js.pool=%d
+		ORDER BY js.rank ASC, j.team_id ASC",
         (int) $poolId,
     );
 
@@ -74,6 +74,7 @@ function ResolvePlayoffPoolStandings($poolId)
             DBQuery("UPDATE uo_team_pool SET activerank=" . ($i + 2) . " WHERE pool=" . intval($poolId) . " AND team=$teamId1");
         } else {
             //keep current positions
+            LogUnresolvedPoolPairAnomaly($poolId, $teamId1, $teamId2);
         }
         //check if teams can be moved to next round
         $gamesleft1 = TeamPoolGamesLeft($teamId1, $poolId);
@@ -94,6 +95,45 @@ function ResolvePlayoffPoolStandings($poolId)
 
     //check if there are special ranking rules and apply them
     CheckSpecialRanking($poolId);
+}
+
+/**
+ * Diagnose why a playoff/cross-match pair's activerank was left unchanged.
+ *
+ * The pair-by-pair resolvers keep the current position whenever the two
+ * compared teams have no net decisive wins between them. That is correct
+ * for a genuine tied score, but the same code path is silently hit when
+ * the two teams paired by seed order never actually played each other
+ * (e.g. a duplicate or otherwise incorrect uo_team_pool.rank), in which
+ * case the displayed standing is left at the pre-game seed instead of
+ * reflecting the real result. Log the two anomalous cases so they show
+ * up in the PHP error log instead of only as a silently wrong bracket.
+ *
+ * @param int $poolId
+ * @param int $teamId1
+ * @param int $teamId2
+ * @return void
+ */
+function LogUnresolvedPoolPairAnomaly($poolId, $teamId1, $teamId2)
+{
+    $query = sprintf(
+        "SELECT COUNT(*) AS total, SUM(isongoing=1) AS ongoing
+			FROM uo_game
+			WHERE ((hometeam=%d AND visitorteam=%d) OR (hometeam=%d AND visitorteam=%d))
+				AND hasstarted>0
+				AND game_id IN (SELECT game FROM uo_game_pool WHERE pool=%d)",
+        (int) $teamId1,
+        (int) $teamId2,
+        (int) $teamId2,
+        (int) $teamId1,
+        (int) $poolId,
+    );
+    $info = DBQueryToRow($query);
+    if ((int) ($info['total'] ?? 0) === 0) {
+        error_log("Pool standings: pool $poolId compared teams $teamId1 and $teamId2 by seed order but found no game between them in this pool; activerank left at its previous value. Check uo_team_pool.rank for duplicate or incorrect values.");
+    } elseif ((int) ($info['ongoing'] ?? 0) > 0) {
+        error_log("Pool standings: pool $poolId teams $teamId1 and $teamId2 have a game still marked ongoing; activerank left at its previous value until the game is finalized.");
+    }
 }
 
 function CheckSpecialRanking($poolId)
@@ -120,10 +160,10 @@ function ResolveCrossMatchPoolStandings($poolId)
     //query pool teams
     $query = sprintf(
         "
-		SELECT j.team_id, js.activerank 
-		FROM uo_team AS j INNER JOIN uo_team_pool AS js ON (j.team_id = js.team) 
-		WHERE js.pool=%d 
-		ORDER BY js.activerank ASC, js.rank ASC",
+		SELECT j.team_id, js.activerank
+		FROM uo_team AS j INNER JOIN uo_team_pool AS js ON (j.team_id = js.team)
+		WHERE js.pool=%d
+		ORDER BY js.activerank ASC, js.rank ASC, j.team_id ASC",
         (int) $poolId,
     );
 
@@ -166,6 +206,7 @@ function ResolveCrossMatchPoolStandings($poolId)
             DBQuery("UPDATE uo_team_pool SET activerank=" . ($i + 2) . " WHERE pool=" . intval($poolId) . " AND team=$teamId1");
         } else {
             //keep current positions
+            LogUnresolvedPoolPairAnomaly($poolId, $teamId1, $teamId2);
         }
         //check if teams can be moved to next round
         $gamesleft1 = TeamPoolGamesLeft($teamId1, $poolId);

--- a/lib/standings.functions.php
+++ b/lib/standings.functions.php
@@ -116,11 +116,14 @@ function ResolvePlayoffPoolStandings($poolId)
  */
 function LogUnresolvedPoolPairAnomaly($poolId, $teamId1, $teamId2)
 {
+    // No hasstarted filter here: a scheduled-but-not-yet-played sibling
+    // pair is a normal, frequent state (every other pair in a multi-match
+    // pool hits this same branch each time one pair's game is resolved),
+    // so it must count as "a game exists" and stay unlogged.
     $query = sprintf(
         "SELECT COUNT(*) AS total, SUM(isongoing=1) AS ongoing
 			FROM uo_game
 			WHERE ((hometeam=%d AND visitorteam=%d) OR (hometeam=%d AND visitorteam=%d))
-				AND hasstarted>0
 				AND game_id IN (SELECT game FROM uo_game_pool WHERE pool=%d)",
         (int) $teamId1,
         (int) $teamId2,


### PR DESCRIPTION
## Summary
- Bruno reported WUCC's Open-division 1-32 placement bracket occasionally showing the losing team in the winner's slot, specifically whenever the away team won - Mixed, with an identical bracket format, never showed it.
- Investigation (see conversation) ruled out a home/away bias in the win-count SQL in `ResolvePlayoffPoolStandings()` / `ResolveCrossMatchPoolStandings()` - it's symmetric and correct on well-formed data.
- Both resolvers silently keep the pre-game seed position whenever the compared pair has zero net decisive wins between them. That's correct for a genuine tied game, but it's the exact same code path a mispaired comparison (e.g. from a duplicate/incorrect `uo_team_pool.rank`) or a game still stuck `isongoing=1` would hit - and today it leaves no trace either way.
- Add a deterministic secondary sort key (`team_id`) to the pool-teams query in both resolvers, and log the two anomalous zero-win cases (no game at all between the pair, or a game still marked ongoing) via `error_log()`. Genuine tied games are left unaffected and unlogged.
- This does not change any activerank/placement output on well-formed data - it's a diagnostics-only change intended to surface the real root cause (in the PHP error log) the next time this happens, since we don't yet have Bruno's DB snapshot to confirm the mechanism directly.

## Test plan
- [x] `composer check` (PHP-CS-Fixer + PHPStan) - clean, 0 findings
- [x] `docs/ai/review-database-access/scripts/check-db-access.php --changed` - clean
- [x] New regression tests added in `ktolonen/ultiorganizer-tests` (companion PR ktolonen/ultiorganizer-tests#8) covering: no-game-between-pair logging, still-ongoing-game logging, and a sanity check that a genuine tied game logs nothing
- [x] Harness `test:quick` (lint 671 / unit 528 / integration 1875) - all passing, no regressions in existing forfeit/tie/BYE/odd-team coverage for both resolvers

Companion test PR: ktolonen/ultiorganizer-tests#8

🤖 Generated with [Claude Code](https://claude.com/claude-code)