### PR TITLE
Fix AGENTS.md/docs inaccuracies and close a release-coverage gap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Prefer reusing shared helpers in `lib/` before adding new utility code or direct
 
 ## Working rules
 
-- Follow the PHP code style described in `docs/code-style.md` (PER-CS 2.0). Run `composer format` and `composer lint` on changed files before handing back work; the pre-commit hook at `.githooks/pre-commit` enforces this on commit.
+- Follow the PHP code style described in `docs/code-style.md` (PER-CS 2.0). Run `composer format` and `composer lint` on changed files before handing back work; the repo ships a pre-commit hook at `.githooks/pre-commit` for this, but it only runs once enabled per clone with `git config core.hooksPath .githooks` — don't assume it's active.
 - Hand-written client JavaScript under `script/` (including the `script/*.inc` `<script>` snippets) is linted with ESLint (`docker compose -f docs/dev/compose.yaml exec -T dev eslint script`). The config lives at `eslint.config.js` in the repo root; the toolchain itself is installed inside the `dev` Docker image, not at the repo root.
 - This is a PHP project, not an npm project: when adding Node-based dev tooling (linters, formatters, etc.), install it inside the `dev` Docker image and ship only the tool's own config file at the repo root (e.g. `eslint.config.js`). Do not add a root `package.json` — it signals an npm project to humans and tooling.
 - Keep SQL and shared data access in `lib/`.
@@ -133,7 +133,7 @@ Pre-commit hooks remain the fast local gate; CI is the source of truth for what 
 - `docs/database-upgrades.md`: schema and migration workflow.
 - `docs/database-access.md`: database access boundaries, allowed helper layers, migration guidance, and checker behavior.
 - `docs/configuration-flags.md`: configuration taxonomy and migration rules. Use the exact type names `SYSTEM_FLAG`, `INSTALLATION_SETTING`, and `EVENT_SETTING`.
-- `docs/permissions.md`: permission storage, roles, and enforcement helpers.
+- `docs/permissions.md`: permission storage, roles, enforcement helpers, and spirit-director behavior.
 - `docs/privacy.md`: privacy admin tools, export scope, and anonymization or deletion behavior by table.
 
 ### Competition workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Prefer reusing shared helpers in `lib/` before adding new utility code or direct
 
 - Follow the PHP code style described in `docs/code-style.md` (PER-CS 2.0). Run `composer format` and `composer lint` on changed files before handing back work; the pre-commit hook at `.githooks/pre-commit` enforces this on commit.
 - Hand-written client JavaScript under `script/` (including the `script/*.inc` `<script>` snippets) is linted with ESLint (`docker compose -f docs/dev/compose.yaml exec -T dev eslint script`). The config lives at `eslint.config.js` in the repo root; the toolchain itself is installed inside the `dev` Docker image, not at the repo root.
+- This is a PHP project, not an npm project: when adding Node-based dev tooling (linters, formatters, etc.), install it inside the `dev` Docker image and ship only the tool's own config file at the repo root (e.g. `eslint.config.js`). Do not add a root `package.json` — it signals an npm project to humans and tooling.
 - Keep SQL and shared data access in `lib/`.
 - `lib/*.functions.php` files are a shared interface, not a scratchpad. A function called from outside `lib/` belongs there even when only one page calls it — that is what the interface is for, and for a mutation it is where the permission check has to live (see the next rule). What does not belong is an internal step split out for the convenience of its neighbours: inline anything whose callers are all in the same file. Search for an existing helper by behavior and table name before adding one — the same query already exists under more than one naming convention (`getTeamSeries()` and `TeamSeason()`).
 - Put permission checks inside reusable `lib/` mutation helpers, not only in routed page handlers, so future callers cannot accidentally bypass access control.
@@ -46,6 +47,7 @@ Prefer reusing shared helpers in `lib/` before adding new utility code or direct
 - When adding a schema change: add `upgradeXX()` in `sql/upgrade_db.php`, bump `DB_VERSION` in `lib/database.php`, and update `sql/ultiorganizer.sql` for fresh installs, including a `uo_database` seed row for the new version. Guard every structural change so re-running the upgrade is safe. Run `docs/ai/db-upgrade-consistency/SKILL.md` afterwards. See `docs/database-upgrades.md`.
 - If the current branch already introduces the latest unmerged database upgrade, fold further schema changes into that upgrade instead of adding another one. Ask the developer to reset or clean the local database so the amended upgrade runs again.
 - Avoid touching `conf/` unless required.
+- Values in `conf/config.inc.php` (`DB_DATABASE`, `CUSTOMIZATIONS`, `BASEURL`, upload paths, etc.) describe one installation, not the project. Read them at the point of use in scripts and checks instead of hardcoding or remembering them — a stale assumed value still returns plausible-looking results, so nothing announces the mistake.
 - Keep edits ASCII unless the file already uses Unicode.
 - If making UI changes, verify both desktop and mobile layouts.
 - After adding or changing CSS, run `docs/ai/css-style-and-lint/SKILL.md` to analyze style consistency and run Stylelint on the changed files.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ This directory collects general project documentation.
 
 - `database-upgrades.md`: schema and migration workflow.
 - `database-access.md`: database access boundaries, allowed helper layers, migration guidance, and checker behavior.
-- `configuration-flags.md`: configuration taxonomy and migration rules.
+- `configuration-flags.md`: configuration taxonomy and migration rules. Use the exact type names `SYSTEM_FLAG`, `INSTALLATION_SETTING`, and `EVENT_SETTING`.
 - `permissions.md`: permission storage, roles, enforcement helpers, and spirit-director behavior.
 - `privacy.md`: privacy admin tools, export scope, and anonymization or deletion behavior by table.
 
@@ -35,10 +35,10 @@ This directory collects general project documentation.
 
 ### Scorekeeping and spirit
 
-- `scorekeeper.md`: Scorekeeper app routing, live clock workflow, and related pages.
+- `scorekeeper.md`: Scorekeeper app routing, responsibility list, live clock workflow, and related pages.
 - `scoresheet.md`: scoresheet concept, input paths, visualization, and database tables.
 - `spirit-scoring.md`: spirit score logic, comments, and related settings.
-- `spiritkeeper.md`: standalone Spiritkeeper app, authenticated and token access modes, and current behavior.
+- `spiritkeeper.md`: standalone Spiritkeeper app, authenticated and token access modes, and visibility rules.
 - `timekeeper.md`: standalone Timekeeper app, template-based time limits, signal timers, and the game clock.
 
 ### Language and output

--- a/docs/ai/release-package-coverage/SKILL.md
+++ b/docs/ai/release-package-coverage/SKILL.md
@@ -28,7 +28,8 @@ produces an error at build time.
 A new top-level app directory has more than one registration point, and the
 release package is only the first:
 
-- `.gitattributes` / `docs/release/build-release.sh` — whether it ships
+- `.gitattributes` — whether it ships
+- `docs/release/build-release.sh` `required_paths` — whether a missing app directory fails the release build's own smoke check
 - `docs/ai/fix-user-language/scripts/update-gettext-catalogs.sh` — whether its strings reach the translation catalogs
 - `menufunctions.php` — whether users can navigate to it
 - `AGENTS.md` and `docs/README.md` — whether it is documented
@@ -59,6 +60,7 @@ The checker reports:
 - `ERROR` — a path classified `runtime` or `runtime-app` that is export-ignored, so it is missing from the package
 - `ERROR` — a path that mixes export-ignored and shipped files
 - `ERROR` — a `runtime-app` directory absent from the gettext scan list
+- `ERROR` — a `runtime-app` directory absent from `build-release.sh`'s `required_paths` smoke check
 - `WARNING` — a stale inventory line for a path that is no longer tracked
 
 ## Classification Kinds
@@ -66,7 +68,7 @@ The checker reports:
 When a new path appears, add one line to `inventory.txt`:
 
 - `runtime` — ships; no tracked file under it is export-ignored
-- `runtime-app` — ships, and its PHP contains translatable strings, so it must also appear in the gettext scan list
+- `runtime-app` — ships, and its PHP contains translatable strings, so it must also appear in the gettext scan list and in `build-release.sh`'s `required_paths`
 - `dev` — development-only; every tracked file under it must be export-ignored
 
 ## Manual Review Rules

--- a/docs/ai/release-package-coverage/scripts/check-release-coverage.php
+++ b/docs/ai/release-package-coverage/scripts/check-release-coverage.php
@@ -15,8 +15,10 @@ declare(strict_types=1);
 //
 //   dev         -> every tracked file under it is export-ignored
 //   runtime     -> no tracked file under it is export-ignored
-//   runtime-app -> same as runtime, and the directory appears in the gettext
-//                  scan list so its translatable strings reach the catalogs
+//   runtime-app -> same as runtime, the directory appears in the gettext
+//                  scan list so its translatable strings reach the catalogs,
+//                  and it appears in build-release.sh's required_paths smoke
+//                  check so a missing app is caught even without gettext strings
 //
 // Usage:
 //   php docs/ai/release-package-coverage/scripts/check-release-coverage.php [options]
@@ -28,6 +30,7 @@ declare(strict_types=1);
 
 const INVENTORY_RELATIVE = 'docs/ai/release-package-coverage/inventory.txt';
 const GETTEXT_SCRIPT_RELATIVE = 'docs/ai/fix-user-language/scripts/update-gettext-catalogs.sh';
+const BUILD_RELEASE_SCRIPT_RELATIVE = 'docs/release/build-release.sh';
 
 function main(array $argv): int
 {
@@ -56,6 +59,7 @@ function main(array $argv): int
     }
 
     $gettextDirs = parseGettextScanList($repo . '/' . GETTEXT_SCRIPT_RELATIVE);
+    $requiredPaths = parseRequiredPaths($repo . '/' . BUILD_RELEASE_SCRIPT_RELATIVE);
 
     $errors = [];
     $warnings = [];
@@ -108,6 +112,14 @@ function main(array $argv): int
             );
         }
 
+        if ($kind === 'runtime-app' && $requiredPaths !== null && !in_array($path, $requiredPaths, true)) {
+            $errors[] = sprintf(
+                '%s is classified "runtime-app" but does not appear in the required_paths smoke check in %s, so a missing app directory would not fail the release build.',
+                $path,
+                BUILD_RELEASE_SCRIPT_RELATIVE,
+            );
+        }
+
         if (!empty($opts['verbose'])) {
             printf("%-12s %s\n", $kind, $path);
         }
@@ -121,6 +133,10 @@ function main(array $argv): int
 
     if ($gettextDirs === null) {
         $warnings[] = 'Could not parse the scan list from ' . GETTEXT_SCRIPT_RELATIVE . '; runtime-app coverage was not verified.';
+    }
+
+    if ($requiredPaths === null) {
+        $warnings[] = 'Could not parse required_paths from ' . BUILD_RELEASE_SCRIPT_RELATIVE . '; runtime-app coverage was not verified.';
     }
 
     if (!empty($opts['verbose'])) {
@@ -266,6 +282,32 @@ function parseGettextScanList(string $file): ?array
         return null;
     }
     return array_values(array_filter($dirs, static fn(string $d): bool => $d !== '' && $d !== '.'));
+}
+
+/**
+ * Extract the base required_paths=(...) array from build-release.sh.
+ *
+ * Only the unconditional array is read; the "install"-only and per-customization
+ * paths appended later in the script are not top-level app directories.
+ *
+ * @return list<string>|null
+ */
+function parseRequiredPaths(string $file): ?array
+{
+    if (!is_file($file)) {
+        return null;
+    }
+    $contents = (string) file_get_contents($file);
+    if (preg_match('/required_paths=\(([^)]*)\)/', $contents, $m) !== 1) {
+        return null;
+    }
+    if (preg_match_all('/"([^"]+)"/', $m[1], $pm) === false) {
+        return null;
+    }
+    return array_map(
+        static fn(string $p): string => explode('/', $p)[0],
+        $pm[1],
+    );
 }
 
 exit(main($argv));

--- a/docs/database-upgrades.md
+++ b/docs/database-upgrades.md
@@ -59,6 +59,24 @@ This page mirrors the database-change guidance from `AGENTS.md`.
 - Manual maintenance never runs `CheckDB()` and is never cleared automatically.
 - The transient lock file `MAINTENANCE_RUNTIME_DIR/maintenance.lock` is used only to serialize the updater; stale locks are recoverable after the fixed timeout in `lib/database.php`.
 
+## Local development: database ahead of the checked-out branch
+
+The automatic maintenance flow (`CheckDB()` via `lib/database.maintenance.php`)
+only runs upgrades forward and then requires `getDBVersion() === DB_VERSION`
+exactly. Switching to a branch whose `DB_VERSION` is *lower* than what is
+already installed — for example, going from a feature branch that bumped the
+schema back to `master` — leaves the installed version higher than
+`DB_VERSION`, which the maintenance gate treats the same as a failed upgrade:
+it writes an `automatic/failed` `maintenance.flag`, and every page shows
+"Database upgrade failed" until it is cleared.
+
+Recover by checking out the branch that owns the newest upgrade (cherry-pick
+it onto the branch you need to run) rather than by editing `uo_database` or
+deleting the flag by hand — a deleted flag alone does not help, since the next
+request recreates it as soon as it sees the version mismatch again. Compare
+`SELECT MAX(version) FROM uo_database` against `DB_VERSION` in
+`lib/database.php` to confirm this is the cause before investigating further.
+
 ## Rules of thumb
 
 - Prefer additive, backward-compatible changes.


### PR DESCRIPTION
## Summary
- Fixed AGENTS.md's claim that the `.githooks/pre-commit` hook enforces formatting on commit — it's actually opt-in per clone (`git config core.hooksPath .githooks`), matching docs/code-style.md.
- Synced four topic descriptions that had drifted between AGENTS.md and docs/README.md (configuration-flags.md, permissions.md, scorekeeper.md, spiritkeeper.md).
- Documented npm/config conventions and closed a release-package-coverage gap (prior commit on this branch).

## Test plan
- [x] Cross-checked every `docs/*.md` and `docs/ai/*/SKILL.md` file is referenced in both AGENTS.md and docs/README.md
- [x] Verified docs/code-style.md's pre-commit hook wording was already correct, only AGENTS.md was wrong
- [x] `git diff` reviewed for both commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFSi8Mw7B2hUfbBMmZ3ZHs