### PR TITLE
Bump application version to 4.1.0

### DIFF
--- a/version.php
+++ b/version.php
@@ -1,3 +1,3 @@
 <?php
 
-return '4.0.0';
+return '4.1.0';


### PR DESCRIPTION
Bumps `version.php` to `4.1.0` in preparation for the v.4.1.0 release tag.

The 4.1 release collects the 25 commits merged since `v.4.0.0`, including Scorekeeper halftime and time cap targets, forfeit win/loss handling, spirit score fixes and visibility tightening, playoff bracket and crossmatch fixes, Callahan statistics, per-event banner images, the player network export plugin, session isolation between co-hosted installations, and persistent cache correctness fixes.

Database schema version advances from 95 to 99, so existing installations run the upgrade path on first request after updating.

Once this is merged, pushing the `v.4.1.0` tag triggers `.github/workflows/release.yml`, which verifies the tag against `version.php`, builds the install and update packages, and publishes the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jd43eCtg5GhiQzLy2UBoMH