### PR TITLE
Fix roster add-player faults and show Member ID in the slkl search dialog

### DIFF
--- a/admin/accreditation.php
+++ b/admin/accreditation.php
@@ -188,13 +188,14 @@ if ($view == "accId") {
         echo "<p><a href='" . $accIdBaseUrl . "&amp;hide_no_games=1'>" . _("Hide players without games") . "</a></p>";
     }
 
+    $players = SeasonPlayerInfos($season);
+    $seasonGames = SeasonPlayerTeamPlayedGames($season);
+
     echo "<h3>" . _("Players without membership Id") . "</h3>";
-    $players = SeasonAllPlayers($season);
     echo "<table class='infotable'><tr><th>" . _("Division") . "</th><th>" . _("Team") . "</th><th>" . _("Player") . "</th><th>" . _("Games") . "</th></tr>";
-    foreach ($players as $player) {
-        $playerinfo = PlayerInfo($player['player_id']);
+    foreach ($players as $playerId => $playerinfo) {
         if (empty($playerinfo['accreditation_id'])) {
-            $gamesPlayed = PlayerSeasonTeamPlayedGames($player['player_id'], $playerinfo['team'], $season);
+            $gamesPlayed = isset($seasonGames[$playerId]) ? $seasonGames[$playerId] : 0;
             if ($hideNoGames && empty($gamesPlayed)) {
                 continue;
             }
@@ -212,27 +213,27 @@ if ($view == "accId") {
     echo "</table>";
 
     echo "<h3>" . _("Players not accredited") . "</h3>";
-    $players = SeasonAllPlayers($season);
     $accRows = [];
-    foreach ($players as $player) {
-        $playerinfo = PlayerInfo($player['player_id']);
+    foreach ($players as $playerId => $playerinfo) {
         if (empty($playerinfo['accredited'])) {
-            $gamesPlayed = PlayerSeasonTeamPlayedGames($player['player_id'], $playerinfo['team'], $season);
+            $gamesPlayed = isset($seasonGames[$playerId]) ? $seasonGames[$playerId] : 0;
             if ($hideNoGames && empty($gamesPlayed)) {
                 continue;
             }
-            $row = [
+            $accRows[] = [
                 'playerinfo' => $playerinfo,
                 'games' => $gamesPlayed,
                 'membership' => '',
                 'external_type' => '',
             ];
-            if (CUSTOMIZATIONS == "slkl") {
-                $licenseRow = LicenseData($playerinfo['accreditation_id']);
-                $row['membership'] = !empty($licenseRow['membership']) ? $licenseRow['membership'] : '';
-                $row['external_type'] = !empty($licenseRow['external_type']) ? $licenseRow['external_type'] : '';
-            }
-            $accRows[] = $row;
+        }
+    }
+    if (CUSTOMIZATIONS == "slkl") {
+        $licenses = LicenseDataList(array_column(array_column($accRows, 'playerinfo'), 'accreditation_id'));
+        foreach ($accRows as $index => $row) {
+            $licenseRow = $licenses[$row['playerinfo']['accreditation_id']] ?? [];
+            $accRows[$index]['membership'] = !empty($licenseRow['membership']) ? $licenseRow['membership'] : '';
+            $accRows[$index]['external_type'] = !empty($licenseRow['external_type']) ? $licenseRow['external_type'] : '';
         }
     }
     if ($sort == "external" && CUSTOMIZATIONS == "slkl") {

--- a/cust/default/teamplayers.functions.php
+++ b/cust/default/teamplayers.functions.php
@@ -77,11 +77,17 @@ echo yuiLoad(["utilities", "datasource", "datatable", "dragdrop", "container"]);
 
 		if (playerId == 0) {
 			YAHOO.util.Dom.get("add").value = "<?php echo _("Confirm"); ?>";
+			YAHOO.util.Dom.get("save").disabled = false;
 			YAHOO.util.Dom.get("cancel").disabled = false;
 		} else {
 			YAHOO.util.Dom.get('showAccrId' + playerId).innerHTML = accrId;
 		}
 		dialog.hide();
+		// After hiding: a viewer without edit rights has no playerEdited field,
+		// so this throws, and it must not leave the dialog stuck open.
+		if (playerId != 0) {
+			ChgPlayer(playerId);
+		}
 		return false;
 	}
 

--- a/cust/default/teamplayers.functions.php
+++ b/cust/default/teamplayers.functions.php
@@ -134,6 +134,13 @@ echo yuiLoad(["utilities", "datasource", "datatable", "dragdrop", "container"]);
 					label: "<?php echo _("Profile ID"); ?>",
 					sortable: true
 				},
+<?php if (CUSTOMIZATIONS == "slkl") { ?>
+				{
+					key: "AccreditationId",
+					label: "<?php echo _("Member ID"); ?>",
+					sortable: true
+				},
+<?php } ?>
 				{
 					key: "Jersey",
 					label: "<?php echo _("#"); ?>",

--- a/lib/accreditation.functions.php
+++ b/lib/accreditation.functions.php
@@ -65,6 +65,39 @@ function LicenseData($accreditation_id)
 }
 
 /**
+ * LicenseData() rows for several accreditation ids at once, keyed by id.
+ *
+ * Ids without a license row are absent from the result, which matches the
+ * empty LicenseData() result the single-id lookup returns for them.
+ *
+ * @param array $accreditationIds
+ * @return array accreditation_id => license row
+ */
+function LicenseDataList($accreditationIds)
+{
+    $ids = [];
+    foreach ($accreditationIds as $accreditationId) {
+        if ($accreditationId === null || $accreditationId === "") {
+            continue;
+        }
+        $ids["'" . DBEscapeString($accreditationId) . "'"] = true;
+    }
+    if (empty($ids)) {
+        return [];
+    }
+
+    $rows = [];
+    foreach (DBQueryToArray("SELECT accreditation_id, membership, license, external_id, external_type,
+		external_validity, ultimate
+		FROM uo_license WHERE accreditation_id IN (" . implode(",", array_keys($ids)) . ")") as $row) {
+        if (!isset($rows[$row['accreditation_id']])) {
+            $rows[$row['accreditation_id']] = $row;
+        }
+    }
+    return $rows;
+}
+
+/**
  * Search license records by player name.
  *
  * @param string $firstname

--- a/lib/player.functions.php
+++ b/lib/player.functions.php
@@ -704,6 +704,68 @@ function SeasonPlayerStatRows($seasonId, $withDefenses = false)
 }
 
 /**
+ * PlayerInfo() rows for every player of a season, keyed by player.
+ *
+ * Same columns and join shape as PlayerInfo(), read in one statement so a
+ * season-wide listing does not issue a read per player. Rows come back in the
+ * SeasonAllPlayers() order, which the keyed array preserves.
+ *
+ * @param string $seasonId
+ * @return array player_id => PlayerInfo() row
+ */
+function SeasonPlayerInfos($seasonId)
+{
+    $query = sprintf(
+        "SELECT p.player_id, p.profile_id, CONCAT(p.firstname, ' ', p.lastname) as name, p.firstname,
+		p.lastname, p.num, p.accreditation_id, p.team, t.name AS teamname, p.accredited,
+		t.series, ser.type, ser.name AS seriesname, pp.profile_image, pp.email, pp.gender,
+		pp.birthdate
+		FROM uo_player p
+		INNER JOIN uo_team t ON (p.team=t.team_id)
+		INNER JOIN uo_series ser ON (ser.series_id=t.series)
+		LEFT JOIN uo_player_profile pp ON (p.profile_id=pp.profile_id)
+		WHERE ser.season='%s'
+		ORDER BY ser.name, t.name, p.lastname, p.firstname",
+        DBEscapeString($seasonId),
+    );
+
+    $rows = [];
+    foreach (DBQueryToArray($query) as $row) {
+        $rows[$row['player_id']] = $row;
+    }
+    return $rows;
+}
+
+/**
+ * Played season games per player on the player's own team, keyed by player.
+ *
+ * Grouped counterpart of PlayerSeasonTeamPlayedGames(). Players without played
+ * games are absent from the result.
+ *
+ * @param string $seasonId
+ * @return array player_id => int
+ */
+function SeasonPlayerTeamPlayedGames($seasonId)
+{
+    $query = sprintf(
+        "SELECT p.player AS player, COUNT(*) AS games
+		FROM uo_played p
+		INNER JOIN uo_player pl ON (pl.player_id=p.player)
+		INNER JOIN uo_game g ON (g.game_id=p.game)
+		WHERE p.game IN (%s)
+		AND (g.hometeam=pl.team OR g.visitorteam=pl.team)
+		GROUP BY p.player",
+        SeasonCompletedGamesSql($seasonId),
+    );
+
+    $games = [];
+    foreach (DBQueryToArray($query) as $row) {
+        $games[$row['player']] = (int) $row['games'];
+    }
+    return $games;
+}
+
+/**
  * Total number of played games on given season by given player.
  *
  * @param int $playerId

--- a/lib/team.functions.php
+++ b/lib/team.functions.php
@@ -1268,6 +1268,9 @@ function RemovePlayer($playerId)
 function AddPlayer($teamId, $firstname, $lastname, $profileId, $num = -1, $regId = null)
 {
     if (hasEditPlayersRight($teamId)) {
+        if (trim((string) $firstname) === '' && trim((string) $lastname) === '') {
+            return 0;
+        }
 
         if (!empty($profileId)) {
             $profile = PlayerProfile($profileId);

--- a/locale/de_DE.utf8/LC_MESSAGES/messages.po
+++ b/locale/de_DE.utf8/LC_MESSAGES/messages.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 10:13+0300\n"
+"POT-Creation-Date: 2026-09-10 23:02+0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: stm <stm2@sourceforge.net>\n"
 "Language-Team: Ultiorganizer\n"
@@ -27,8 +27,8 @@ msgid " (enter '0' if not live)"
 msgstr " (gib '0' ein, wenn nicht live)"
 
 #: cust/default/pdfscoresheet.php:180 cust/default/pdfscoresheet.php:190
-#: cust/default/teamplayers.functions.php:139 cust/slkl/pdfscoresheet.php:145
-#: cust/slkl/pdfscoresheet.php:155 user/teamplayers.php:162
+#: cust/default/teamplayers.functions.php:146 cust/slkl/pdfscoresheet.php:145
+#: cust/slkl/pdfscoresheet.php:155 user/teamplayers.php:166
 msgid "#"
 msgstr "#"
 
@@ -253,7 +253,7 @@ msgstr "Akkreditierungslog"
 msgid "Accreditation official"
 msgstr "Akkreditierungsverantwortlicher"
 
-#: user/teamplayers.php:166
+#: user/teamplayers.php:170
 msgid "Accredited"
 msgstr "Akkreditiert"
 
@@ -288,7 +288,7 @@ msgstr "Aktiv"
 #: admin/seasons.php:157 admin/seasonseries.php:173 admin/seasonteams.php:263
 #: admin/serieformats.php:52 admin/timekeepertemplates.php:61
 #: admin/translations.php:522 user/addextraemail.php:95 user/enrollteam.php:140
-#: user/teamplayers.php:269 user/userinfo.php:378 user/userinfo.php:516
+#: user/teamplayers.php:273 user/userinfo.php:378 user/userinfo.php:516
 msgid "Add"
 msgstr "Hinzufügen"
 
@@ -352,7 +352,7 @@ msgstr "Neuer Benutzer"
 msgid "Add pause"
 msgstr "Pause hinzufügen"
 
-#: user/teamplayers.php:142
+#: user/teamplayers.php:146
 msgid "Add players to team's roster:"
 msgstr "Füge Spieler zur Spielerliste hinzu:"
 
@@ -705,7 +705,7 @@ msgstr "Vorlagengeber nicht auf der Spielerliste"
 #: gamecard.php:241 gamecard.php:247 gameplay.php:136 gameplay.php:157
 #: playerlist.php:36 poolstatus.php:161 poolstatus.php:187 seriesstatus.php:309
 #: teamcard.php:124 teamcard.php:169 ext/poolscoreboard.php:41
-#: ext/teamscoreboard.php:56 lib/common.functions.php:1721
+#: ext/teamscoreboard.php:56 lib/common.functions.php:1725
 msgid "Assists"
 msgstr "Assists"
 
@@ -733,7 +733,7 @@ msgstr "Automatische Akkreditierung"
 msgid "Automatic final standings, not confirmed"
 msgstr "Automatische Endplatzierungen, nicht bestätigt"
 
-#: teamcard.php:279 lib/common.functions.php:1732
+#: teamcard.php:279 lib/common.functions.php:1736
 msgid "Average"
 msgstr "Durchschnitt"
 
@@ -800,7 +800,7 @@ msgstr "Zurück zu"
 msgid "Back to Spirit tools"
 msgstr "Zurueck zu den Spirit-Werkzeugen"
 
-#: user/teamplayers.php:291
+#: user/teamplayers.php:295
 msgid "Back to entering player numbers"
 msgstr "Zurück zur Spielernummerneingabe"
 
@@ -939,7 +939,7 @@ msgid "Call or discussion"
 msgstr "Call oder Diskussion"
 
 #: cust/default/pdfscoresheet.php:638 cust/gummis/pdfscoresheet.php:698
-#: cust/wfdf/pdfscoresheet.php:1273 lib/common.functions.php:1724
+#: cust/wfdf/pdfscoresheet.php:1273 lib/common.functions.php:1728
 #: user/adddefensesheet.php:358
 msgid "Callahan"
 msgstr "Callahan"
@@ -970,7 +970,7 @@ msgstr "Callahan-Punkt"
 #: scorekeeper/result.php:88 user/adddefensesheet.php:317
 #: user/addscoresheet.php:708 user/select_poolselector.php:26
 #: user/select_poolselector.php:29 user/select_poolselector.php:32
-#: user/select_poolselector.php:35 user/teamplayers.php:280
+#: user/select_poolselector.php:35 user/teamplayers.php:284
 #: user/userinfo.php:292
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -1194,7 +1194,7 @@ msgstr "Verein"
 msgid "Club Card"
 msgstr "Vereinskarte"
 
-#: user/clubprofile.php:141 user/teamplayers.php:138 user/teamprofile.php:100
+#: user/clubprofile.php:141 user/teamplayers.php:142 user/teamprofile.php:100
 msgid "Club Profile"
 msgstr "Club-Profil"
 
@@ -1411,11 +1411,11 @@ msgstr "Jetzt nach InnoDB/utf8mb4 umwandeln"
 msgid "Coordinates"
 msgstr "Koordinaten"
 
-#: admin/seasonteams.php:288 user/teamplayers.php:195
+#: admin/seasonteams.php:288 user/teamplayers.php:199
 msgid "Copy"
 msgstr "Kopieren"
 
-#: user/teamplayers.php:186
+#: user/teamplayers.php:190
 msgid "Copy team roster from:"
 msgstr "Spielerliste kopieren von:"
 
@@ -1589,7 +1589,7 @@ msgstr "Datenbankversion"
 msgid "Date"
 msgstr "Datum"
 
-#: playercard.php:97 cust/default/teamplayers.functions.php:154
+#: playercard.php:97 cust/default/teamplayers.functions.php:161
 #: user/playerprofile.php:271
 msgid "Date of birth"
 msgstr "Geburtstag"
@@ -1646,7 +1646,7 @@ msgstr "Defensebogen gespeichert"
 
 #: defensestatus.php:80 defensestatus.php:82 gameplay.php:679 gameplay.php:702
 #: teamcard.php:127 teamcard.php:430 teamcard.php:521
-#: cust/wfdf/pdfscoresheet.php:252 lib/common.functions.php:1726
+#: cust/wfdf/pdfscoresheet.php:252 lib/common.functions.php:1730
 msgid "Defences"
 msgstr "Defenses"
 
@@ -1657,7 +1657,7 @@ msgstr "Defensivaktionen"
 #: admin/poolmoves.php:233 admin/poolmoves.php:305 admin/seasonpoints.php:204
 #: admin/spirit.php:403 admin/translations.php:550 admin/users.php:93
 #: admin/users.php:95 mobile/deletescore.php:23 mobile/deletescore.php:47
-#: scorekeeper/deletescore.php:44 user/teamplayers.php:175
+#: scorekeeper/deletescore.php:44 user/teamplayers.php:179
 msgid "Delete"
 msgstr "Löschen"
 
@@ -1913,7 +1913,7 @@ msgstr "Datenschutzbericht des Spielers herunterladen"
 msgid "Download registered user privacy report"
 msgstr "Datenschutzbericht des registrierten Benutzers herunterladen"
 
-#: lib/common.functions.php:1708
+#: lib/common.functions.php:1712
 msgid "Draws"
 msgstr "Unentschieden"
 
@@ -2431,12 +2431,12 @@ msgid "Fields"
 msgstr "Felder"
 
 #: lib/club.functions.php:211 lib/player.functions.php:1109
-#: lib/season.functions.php:1303 lib/team.functions.php:1416
+#: lib/season.functions.php:1306 lib/team.functions.php:1419
 msgid "File is not supported image format"
 msgstr "Dateiformat wird nicht unterstützt"
 
 #: lib/club.functions.php:203 lib/player.functions.php:1101
-#: lib/season.functions.php:1298 lib/team.functions.php:1408
+#: lib/season.functions.php:1301 lib/team.functions.php:1411
 msgid "File is too large"
 msgstr "Datei ist zu groß"
 
@@ -2538,8 +2538,8 @@ msgstr "Vorname"
 msgid "First Offence"
 msgstr "Erste Offence"
 
-#: cust/default/teamplayers.functions.php:144 user/playerprofile.php:222
-#: user/teamplayers.php:163
+#: cust/default/teamplayers.functions.php:151 user/playerprofile.php:222
+#: user/teamplayers.php:167
 msgid "First name"
 msgstr "Vorname"
 
@@ -2572,7 +2572,7 @@ msgstr "Folge den Anweisungen in der Email, um die Adresse zu bestätigen"
 msgid "Follow the link in the email to confirm your registration."
 msgstr "Folge dem Link in der Email, um die Registrierung zu bestätigen."
 
-#: frontpage.php:35
+#: frontpage.php:40
 msgid "For feedback, improvement ideas, or any other questions, contact:"
 msgstr ""
 "Für Feedback, Verbesserungsvorschläge und alle anderen Fragen wenden Sie "
@@ -2913,7 +2913,7 @@ msgstr "Zusammenfassung des Spielverlaufs"
 #: admin/seasonstandings.php:313 admin/seasonstandings.php:370
 #: admin/seasonstats.php:21 admin/seasonstats.php:35 admin/seriesgames.php:31
 #: admin/seriesgames.php:41 admin/stats.php:120 ext/poolscoreboard.php:40
-#: ext/teamscoreboard.php:55 lib/common.functions.php:1704
+#: ext/teamscoreboard.php:55 lib/common.functions.php:1708
 #: lib/search.functions.php:786
 msgid "Games"
 msgstr "Spiele"
@@ -3021,11 +3021,11 @@ msgstr "Zeit des Punktes"
 #: gameplay.php:540 playerlist.php:37 poolstatus.php:161 poolstatus.php:187
 #: poolstatus.php:302 seriesstatus.php:309 teamcard.php:125 teamcard.php:170
 #: ext/poolscoreboard.php:42 ext/teamscoreboard.php:57
-#: lib/common.functions.php:1719
+#: lib/common.functions.php:1723
 msgid "Goals"
 msgstr "Punkte"
 
-#: lib/common.functions.php:1714
+#: lib/common.functions.php:1718
 msgid "Goals against"
 msgstr "Gegenpunkte"
 
@@ -3033,11 +3033,11 @@ msgstr "Gegenpunkte"
 msgid "Goals against avg."
 msgstr "Gegenpunkte im Schnitt"
 
-#: lib/common.functions.php:1716
+#: lib/common.functions.php:1720
 msgid "Goals diff"
 msgstr "Punktedifferenz"
 
-#: lib/common.functions.php:1712
+#: lib/common.functions.php:1716
 msgid "Goals for"
 msgstr "Punkte"
 
@@ -3338,8 +3338,8 @@ msgid ""
 msgstr ""
 
 #: lib/club.functions.php:234 lib/player.functions.php:1132
-#: lib/season.functions.php:1331 lib/season.functions.php:1335
-#: lib/team.functions.php:1440
+#: lib/season.functions.php:1334 lib/season.functions.php:1338
+#: lib/team.functions.php:1443
 msgid "Image upload failed because the server could not process the image."
 msgstr ""
 "Das Hochladen des Bildes ist fehlgeschlagen, weil der Server das Bild nicht "
@@ -3512,7 +3512,7 @@ msgstr "Ungültiges Spiel."
 msgid "Invalid link target."
 msgstr "Ungueltiges Linkziel."
 
-#: install.php:718
+#: install.php:739
 msgid "Invalid password (min. 5, max. 20 characters)."
 msgstr "Ungueltiges Passwort (min. 5, max. 20 Zeichen)."
 
@@ -3636,8 +3636,8 @@ msgstr "Nachname"
 msgid "Last login"
 msgstr "Letztes Login"
 
-#: cust/default/teamplayers.functions.php:149 user/playerprofile.php:226
-#: user/teamplayers.php:164
+#: cust/default/teamplayers.functions.php:156 user/playerprofile.php:226
+#: user/teamplayers.php:168
 msgid "Last name"
 msgstr "Nachmane"
 
@@ -3678,7 +3678,7 @@ msgstr ""
 "Kommentar sehen, sobald beide Teams abgegeben haben, ohne die Kommentare "
 "öffentlich zu machen."
 
-#: user/playerprofile.php:197 user/teamplayers.php:170
+#: user/playerprofile.php:197 user/teamplayers.php:174
 msgid "License"
 msgstr "Lizenz"
 
@@ -3814,7 +3814,7 @@ msgstr "Länge"
 msgid "Losers continue in:"
 msgstr "Verlierer macht weiter in:"
 
-#: lib/common.functions.php:1710
+#: lib/common.functions.php:1714
 msgid "Losses"
 msgstr "Niederlagen"
 
@@ -3887,12 +3887,12 @@ msgstr "Masseneingabe"
 msgid "Media owner"
 msgstr "Medienbesitzer"
 
-#: user/teamplayers.php:168
+#: cust/default/teamplayers.functions.php:140 user/teamplayers.php:172
 msgid "Member ID"
 msgstr "Mitgliedsnummer"
 
 #: admin/accreditation.php:259 admin/accreditation.php:261
-#: user/playerprofile.php:207 user/teamplayers.php:169
+#: user/playerprofile.php:207 user/teamplayers.php:173
 msgid "Membership"
 msgstr "Mitgliedschaft"
 
@@ -3938,7 +3938,7 @@ msgid "Missing and duplicate shirt numbers"
 msgstr "Fehlende und doppelte Trikotnummern"
 
 #: lib/club.functions.php:215 lib/player.functions.php:1113
-#: lib/season.functions.php:1307 lib/team.functions.php:1420
+#: lib/season.functions.php:1310 lib/team.functions.php:1423
 msgid "Missing image processing support on the server."
 msgstr "Auf dem Server fehlt die Unterstuetzung fuer Bildverarbeitung."
 
@@ -4114,7 +4114,7 @@ msgstr "Name darf nicht leer sein"
 msgid "Name in Schedule"
 msgstr "Name im Spielplan"
 
-#: admin/addseasonteams.php:40
+#: admin/addseasonteams.php:40 user/teamplayers.php:59
 msgid "Name is mandatory!"
 msgstr "Name ist erforderlich!"
 
@@ -4166,7 +4166,7 @@ msgstr "Neue lizenzierte Spieler hinzugefuegt:"
 msgid "New name"
 msgstr "Neuer Name"
 
-#: user/teamplayers.php:145
+#: user/teamplayers.php:149
 msgid ""
 "New players: enter the jersey number, first name, and last name. Press the "
 "Add button."
@@ -4198,7 +4198,7 @@ msgstr "Weiter"
 msgid "Nickname"
 msgstr "Spitzname"
 
-#: user/teamplayers.php:229
+#: user/teamplayers.php:233
 msgid "No"
 msgstr "Nein"
 
@@ -4279,7 +4279,7 @@ msgstr "Keine Punkte."
 msgid "No image"
 msgstr "Kein Bild"
 
-#: lib/season.functions.php:1294
+#: lib/season.functions.php:1297
 #, fuzzy
 msgid "No image selected."
 msgstr "Ausgewähltes zusammenfügen"
@@ -4841,7 +4841,7 @@ msgstr "Spieler nicht akkreditiert"
 msgid "Players of the game"
 msgstr "Aktive Spieler"
 
-#: user/teamplayers.php:144
+#: user/teamplayers.php:148
 msgid ""
 "Players who already have a profile in Ultiorganizer: enter the full player "
 "name or part of it and press the Search button. Select the correct player "
@@ -4999,11 +4999,11 @@ msgstr "Positive Einstellung und Selbstkontrolle (ihre)"
 msgid "Press the button to search for spirit comments"
 msgstr "Druecke die Schaltflaeche, um nach Spirit-Kommentaren zu suchen"
 
-#: cust/default/teamplayers.functions.php:165
+#: cust/default/teamplayers.functions.php:172
 msgid "Prev. Event"
 msgstr "Vorheriges Turnier"
 
-#: cust/default/teamplayers.functions.php:160
+#: cust/default/teamplayers.functions.php:167
 msgid "Prev. Team"
 msgstr "Vorheriges Team"
 
@@ -5037,7 +5037,7 @@ msgstr "Alle Spielberichte drucken"
 msgid "Print blank scoresheet"
 msgstr "Leeren Spielbericht drucken"
 
-#: user/teamplayers.php:301
+#: user/teamplayers.php:305
 msgid "Print roster"
 msgstr "Spielerliste drucken"
 
@@ -5071,12 +5071,12 @@ msgstr "Datenschutzerklärung"
 msgid "Private field %s.%s cannot be imported from an event snapshot."
 msgstr ""
 
-#: admin/dbequalize.php:117 user/teamplayers.php:165
+#: admin/dbequalize.php:117 user/teamplayers.php:169
 msgid "Profile"
 msgstr "Profil"
 
 #: admin/dbequalize.php:367 admin/dbequalize.php:370
-#: cust/default/teamplayers.functions.php:134 user/teamplayers.php:173
+#: cust/default/teamplayers.functions.php:134 user/teamplayers.php:177
 msgid "Profile ID"
 msgstr "Profil-ID"
 
@@ -5424,7 +5424,7 @@ msgstr "Rechte"
 #: scorekeeper/addplayerlists.php:258 scorekeeper/addscoresheet.php:509
 #: scorekeeper/addscoresheet.php:528 scorekeeper/respgames.php:200
 #: user/clubprofile.php:139 user/respteams.php:24 user/teamplayers.php:11
-#: user/teamplayers.php:136 user/teamprofile.php:98
+#: user/teamplayers.php:140 user/teamprofile.php:98
 msgid "Roster"
 msgstr "Spielerliste"
 
@@ -5559,7 +5559,7 @@ msgstr "Samstag"
 #: scorekeeper/result.php:101 spiritkeeper/editgame.php:125
 #: user/addmedialink.php:219 user/addplayerlists.php:453 user/addspirit.php:314
 #: user/clubprofile.php:251 user/playerprofile.php:389 user/respgames.php:230
-#: user/teamplayers.php:279 user/teamprofile.php:191 user/userinfo.php:291
+#: user/teamplayers.php:283 user/teamprofile.php:191 user/userinfo.php:291
 msgid "Save"
 msgstr "Speichern"
 
@@ -5801,7 +5801,7 @@ msgstr "Scorendes Team"
 #: lib/search.functions.php:86 lib/search.functions.php:128
 #: lib/search.functions.php:191 lib/search.functions.php:249
 #: lib/search.functions.php:318 lib/search.functions.php:399
-#: user/teamplayers.php:238 user/teamplayers.php:268
+#: user/teamplayers.php:242 user/teamplayers.php:272
 msgid "Search"
 msgstr "Suchen"
 
@@ -6606,7 +6606,7 @@ msgstr "Aufgaben"
 msgid "Team"
 msgstr "Team"
 
-#: user/clubprofile.php:140 user/teamplayers.php:137 user/teamprofile.php:99
+#: user/clubprofile.php:140 user/teamplayers.php:141 user/teamprofile.php:99
 msgid "Team Profile"
 msgstr "Teamprofil"
 
@@ -7151,7 +7151,7 @@ msgstr "Tot."
 #: teamcard.php:320 teamcard.php:364 teamcard.php:586 teamcard.php:777
 #: admin/spirit.php:47 admin/spirit.php:106 admin/spirit.php:155
 #: admin/spirit.php:238 admin/spirit.php:282 admin/spirit.php:342
-#: cust/slkl/mass-accreditation.php:86 lib/common.functions.php:1728
+#: cust/slkl/mass-accreditation.php:86 lib/common.functions.php:1732
 #: spiritkeeper/submitsotg.php:90
 msgid "Total"
 msgstr "Total"
@@ -7451,7 +7451,7 @@ msgstr ""
 msgid "User"
 msgstr "Benutzer"
 
-#: frontpage.php:29 menufunctions.php:732 user_guide.php:7
+#: frontpage.php:34 menufunctions.php:732 user_guide.php:7
 msgid "User Guide"
 msgstr "Anleitung"
 
@@ -7713,7 +7713,7 @@ msgstr "Sieger macht weiter in:"
 msgid "Winning points"
 msgstr "Gewinnpunkte"
 
-#: lib/common.functions.php:1706
+#: lib/common.functions.php:1710
 msgid "Wins"
 msgstr "Siege"
 
@@ -7742,7 +7742,7 @@ msgstr "World Flying Disc Federation"
 msgid "X"
 msgstr "X"
 
-#: admin/timekeepertemplates.php:45 user/teamplayers.php:227
+#: admin/timekeepertemplates.php:45 user/teamplayers.php:231
 msgid "Yes"
 msgstr "Ja"
 
@@ -7898,7 +7898,7 @@ msgstr "Klasse"
 
 #: admin/editstanding.php:73 admin/poolgames.php:289 admin/poolgames.php:330
 #: admin/poolgames.php:354 plugins/lisence_modifier.php:240
-#: user/teamplayers.php:210
+#: user/teamplayers.php:214
 msgid "edit"
 msgstr "bearbeiten"
 
@@ -8282,7 +8282,7 @@ msgstr "Unbekannter Club"
 msgid "update"
 msgstr "update"
 
-#: user/teamplayers.php:211
+#: user/teamplayers.php:215
 msgid "view"
 msgstr "anzeigen"
 

--- a/locale/es_ES.utf8/LC_MESSAGES/messages.po
+++ b/locale/es_ES.utf8/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 10:13+0300\n"
+"POT-Creation-Date: 2026-09-10 23:02+0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: stm <stm2@sourceforge.net>\n"
 "Language-Team: Ultiorganizer\n"
@@ -28,8 +28,8 @@ msgid " (enter '0' if not live)"
 msgstr " (ingrese '0' si no está activo)"
 
 #: cust/default/pdfscoresheet.php:180 cust/default/pdfscoresheet.php:190
-#: cust/default/teamplayers.functions.php:139 cust/slkl/pdfscoresheet.php:145
-#: cust/slkl/pdfscoresheet.php:155 user/teamplayers.php:162
+#: cust/default/teamplayers.functions.php:146 cust/slkl/pdfscoresheet.php:145
+#: cust/slkl/pdfscoresheet.php:155 user/teamplayers.php:166
 msgid "#"
 msgstr "#"
 
@@ -258,7 +258,7 @@ msgstr "Registro de Acreditación"
 msgid "Accreditation official"
 msgstr "Oficial de Acreditación"
 
-#: user/teamplayers.php:166
+#: user/teamplayers.php:170
 msgid "Accredited"
 msgstr "Autorizado"
 
@@ -293,7 +293,7 @@ msgstr "Activo"
 #: admin/seasons.php:157 admin/seasonseries.php:173 admin/seasonteams.php:263
 #: admin/serieformats.php:52 admin/timekeepertemplates.php:61
 #: admin/translations.php:522 user/addextraemail.php:95 user/enrollteam.php:140
-#: user/teamplayers.php:269 user/userinfo.php:378 user/userinfo.php:516
+#: user/teamplayers.php:273 user/userinfo.php:378 user/userinfo.php:516
 msgid "Add"
 msgstr "Agregar"
 
@@ -357,7 +357,7 @@ msgstr "Agregar nuevo usuario"
 msgid "Add pause"
 msgstr "Agregar pausa"
 
-#: user/teamplayers.php:142
+#: user/teamplayers.php:146
 msgid "Add players to team's roster:"
 msgstr "Agregar jugadores a la plantilla del equipo:"
 
@@ -714,7 +714,7 @@ msgstr "Jugador asistente no está en la lista de jugadores"
 #: gamecard.php:241 gamecard.php:247 gameplay.php:136 gameplay.php:157
 #: playerlist.php:36 poolstatus.php:161 poolstatus.php:187 seriesstatus.php:309
 #: teamcard.php:124 teamcard.php:169 ext/poolscoreboard.php:41
-#: ext/teamscoreboard.php:56 lib/common.functions.php:1721
+#: ext/teamscoreboard.php:56 lib/common.functions.php:1725
 msgid "Assists"
 msgstr "Asistencias"
 
@@ -742,7 +742,7 @@ msgstr "Acreditación Automática"
 msgid "Automatic final standings, not confirmed"
 msgstr "Clasificación final automática, no confirmada"
 
-#: teamcard.php:279 lib/common.functions.php:1732
+#: teamcard.php:279 lib/common.functions.php:1736
 msgid "Average"
 msgstr "Promedio"
 
@@ -809,7 +809,7 @@ msgstr "Volver a"
 msgid "Back to Spirit tools"
 msgstr "Volver a herramientas de Espíritu"
 
-#: user/teamplayers.php:291
+#: user/teamplayers.php:295
 msgid "Back to entering player numbers"
 msgstr "Volver a ingresar números de jugadores"
 
@@ -948,7 +948,7 @@ msgid "Call or discussion"
 msgstr "Llamada o discusión"
 
 #: cust/default/pdfscoresheet.php:638 cust/gummis/pdfscoresheet.php:698
-#: cust/wfdf/pdfscoresheet.php:1273 lib/common.functions.php:1724
+#: cust/wfdf/pdfscoresheet.php:1273 lib/common.functions.php:1728
 #: user/adddefensesheet.php:358
 msgid "Callahan"
 msgstr "Callahan"
@@ -979,7 +979,7 @@ msgstr "Gol de Callahan"
 #: scorekeeper/result.php:88 user/adddefensesheet.php:317
 #: user/addscoresheet.php:708 user/select_poolselector.php:26
 #: user/select_poolselector.php:29 user/select_poolselector.php:32
-#: user/select_poolselector.php:35 user/teamplayers.php:280
+#: user/select_poolselector.php:35 user/teamplayers.php:284
 #: user/userinfo.php:292
 msgid "Cancel"
 msgstr "Cancelar"
@@ -1203,7 +1203,7 @@ msgstr "Club"
 msgid "Club Card"
 msgstr "Ficha del Club"
 
-#: user/clubprofile.php:141 user/teamplayers.php:138 user/teamprofile.php:100
+#: user/clubprofile.php:141 user/teamplayers.php:142 user/teamprofile.php:100
 msgid "Club Profile"
 msgstr "Perfil del Club"
 
@@ -1424,11 +1424,11 @@ msgstr "Convierta a InnoDB/utf8mb4 ahora"
 msgid "Coordinates"
 msgstr "Coordenadas"
 
-#: admin/seasonteams.php:288 user/teamplayers.php:195
+#: admin/seasonteams.php:288 user/teamplayers.php:199
 msgid "Copy"
 msgstr "Copiar"
 
-#: user/teamplayers.php:186
+#: user/teamplayers.php:190
 msgid "Copy team roster from:"
 msgstr "Copiar la lista de jugadores del equipo desde:"
 
@@ -1602,7 +1602,7 @@ msgstr "Versión de la base de datos"
 msgid "Date"
 msgstr "Fecha"
 
-#: playercard.php:97 cust/default/teamplayers.functions.php:154
+#: playercard.php:97 cust/default/teamplayers.functions.php:161
 #: user/playerprofile.php:271
 msgid "Date of birth"
 msgstr "Fecha de nacimiento"
@@ -1659,7 +1659,7 @@ msgstr "Hoja de Defensa guardada"
 
 #: defensestatus.php:80 defensestatus.php:82 gameplay.php:679 gameplay.php:702
 #: teamcard.php:127 teamcard.php:430 teamcard.php:521
-#: cust/wfdf/pdfscoresheet.php:252 lib/common.functions.php:1726
+#: cust/wfdf/pdfscoresheet.php:252 lib/common.functions.php:1730
 msgid "Defences"
 msgstr "Defensas"
 
@@ -1670,7 +1670,7 @@ msgstr "Jugadas defensivas"
 #: admin/poolmoves.php:233 admin/poolmoves.php:305 admin/seasonpoints.php:204
 #: admin/spirit.php:403 admin/translations.php:550 admin/users.php:93
 #: admin/users.php:95 mobile/deletescore.php:23 mobile/deletescore.php:47
-#: scorekeeper/deletescore.php:44 user/teamplayers.php:175
+#: scorekeeper/deletescore.php:44 user/teamplayers.php:179
 msgid "Delete"
 msgstr "Borrar"
 
@@ -1925,7 +1925,7 @@ msgstr "Descargar informe de privacidad del jugador"
 msgid "Download registered user privacy report"
 msgstr "Descargar informe de privacidad de usuario registrado"
 
-#: lib/common.functions.php:1708
+#: lib/common.functions.php:1712
 msgid "Draws"
 msgstr "Empates"
 
@@ -2444,12 +2444,12 @@ msgid "Fields"
 msgstr "Campos"
 
 #: lib/club.functions.php:211 lib/player.functions.php:1109
-#: lib/season.functions.php:1303 lib/team.functions.php:1416
+#: lib/season.functions.php:1306 lib/team.functions.php:1419
 msgid "File is not supported image format"
 msgstr "El archivo no es un formato de imagen compatible"
 
 #: lib/club.functions.php:203 lib/player.functions.php:1101
-#: lib/season.functions.php:1298 lib/team.functions.php:1408
+#: lib/season.functions.php:1301 lib/team.functions.php:1411
 msgid "File is too large"
 msgstr "El archivo es demasiado grande"
 
@@ -2551,8 +2551,8 @@ msgstr "Primer Nombre"
 msgid "First Offence"
 msgstr "Primero a la Ofensiva"
 
-#: cust/default/teamplayers.functions.php:144 user/playerprofile.php:222
-#: user/teamplayers.php:163
+#: cust/default/teamplayers.functions.php:151 user/playerprofile.php:222
+#: user/teamplayers.php:167
 msgid "First name"
 msgstr "Primer nombre"
 
@@ -2586,7 +2586,7 @@ msgstr ""
 msgid "Follow the link in the email to confirm your registration."
 msgstr "Siga el enlace en el correo electrónico para confirmar su registro."
 
-#: frontpage.php:35
+#: frontpage.php:40
 msgid "For feedback, improvement ideas, or any other questions, contact:"
 msgstr ""
 "Para comentarios, ideas de mejora o cualquier otra pregunta, comuníquese con:"
@@ -2927,7 +2927,7 @@ msgstr "Resumen del juego"
 #: admin/seasonstandings.php:313 admin/seasonstandings.php:370
 #: admin/seasonstats.php:21 admin/seasonstats.php:35 admin/seriesgames.php:31
 #: admin/seriesgames.php:41 admin/stats.php:120 ext/poolscoreboard.php:40
-#: ext/teamscoreboard.php:55 lib/common.functions.php:1704
+#: ext/teamscoreboard.php:55 lib/common.functions.php:1708
 #: lib/search.functions.php:786
 msgid "Games"
 msgstr "Juegos"
@@ -3035,11 +3035,11 @@ msgstr "Tiempo de gol"
 #: gameplay.php:540 playerlist.php:37 poolstatus.php:161 poolstatus.php:187
 #: poolstatus.php:302 seriesstatus.php:309 teamcard.php:125 teamcard.php:170
 #: ext/poolscoreboard.php:42 ext/teamscoreboard.php:57
-#: lib/common.functions.php:1719
+#: lib/common.functions.php:1723
 msgid "Goals"
 msgstr "Goles"
 
-#: lib/common.functions.php:1714
+#: lib/common.functions.php:1718
 msgid "Goals against"
 msgstr "Goles en contra"
 
@@ -3047,11 +3047,11 @@ msgstr "Goles en contra"
 msgid "Goals against avg."
 msgstr "Goles en contra avg."
 
-#: lib/common.functions.php:1716
+#: lib/common.functions.php:1720
 msgid "Goals diff"
 msgstr "Goles diff"
 
-#: lib/common.functions.php:1712
+#: lib/common.functions.php:1716
 msgid "Goals for"
 msgstr "Goles a favor"
 
@@ -3352,8 +3352,8 @@ msgid ""
 msgstr ""
 
 #: lib/club.functions.php:234 lib/player.functions.php:1132
-#: lib/season.functions.php:1331 lib/season.functions.php:1335
-#: lib/team.functions.php:1440
+#: lib/season.functions.php:1334 lib/season.functions.php:1338
+#: lib/team.functions.php:1443
 msgid "Image upload failed because the server could not process the image."
 msgstr ""
 "La carga de la imagen falló porque el servidor no pudo procesar la imagen."
@@ -3525,7 +3525,7 @@ msgstr "Juego no válido."
 msgid "Invalid link target."
 msgstr "Destino de enlace no válido."
 
-#: install.php:718
+#: install.php:739
 msgid "Invalid password (min. 5, max. 20 characters)."
 msgstr "Contraseña no válida (mínimo 5, máximo 20 caracteres)."
 
@@ -3648,8 +3648,8 @@ msgstr "Apellido"
 msgid "Last login"
 msgstr "Último inicio de sesión"
 
-#: cust/default/teamplayers.functions.php:149 user/playerprofile.php:226
-#: user/teamplayers.php:164
+#: cust/default/teamplayers.functions.php:156 user/playerprofile.php:226
+#: user/teamplayers.php:168
 msgid "Last name"
 msgstr "Apellido"
 
@@ -3690,7 +3690,7 @@ msgstr ""
 "Spiritkeeper una vez que ambos equipos lo han enviado, sin hacer públicos "
 "los comentarios."
 
-#: user/playerprofile.php:197 user/teamplayers.php:170
+#: user/playerprofile.php:197 user/teamplayers.php:174
 msgid "License"
 msgstr "Licencia"
 
@@ -3826,7 +3826,7 @@ msgstr "Longitud"
 msgid "Losers continue in:"
 msgstr "Los perdedores continúan en:"
 
-#: lib/common.functions.php:1710
+#: lib/common.functions.php:1714
 msgid "Losses"
 msgstr "Pérdidas"
 
@@ -3900,12 +3900,12 @@ msgstr "Entrada masiva"
 msgid "Media owner"
 msgstr "Propietario del medio"
 
-#: user/teamplayers.php:168
+#: cust/default/teamplayers.functions.php:140 user/teamplayers.php:172
 msgid "Member ID"
 msgstr "ID de miembro"
 
 #: admin/accreditation.php:259 admin/accreditation.php:261
-#: user/playerprofile.php:207 user/teamplayers.php:169
+#: user/playerprofile.php:207 user/teamplayers.php:173
 msgid "Membership"
 msgstr "Afiliación"
 
@@ -3950,7 +3950,7 @@ msgid "Missing and duplicate shirt numbers"
 msgstr "Números de camiseta faltantes y duplicados"
 
 #: lib/club.functions.php:215 lib/player.functions.php:1113
-#: lib/season.functions.php:1307 lib/team.functions.php:1420
+#: lib/season.functions.php:1310 lib/team.functions.php:1423
 msgid "Missing image processing support on the server."
 msgstr "Falta soporte de procesamiento de imágenes en el servidor."
 
@@ -4126,7 +4126,7 @@ msgstr "El nombre no puede estar vacío"
 msgid "Name in Schedule"
 msgstr "Nombre en el Calendario"
 
-#: admin/addseasonteams.php:40
+#: admin/addseasonteams.php:40 user/teamplayers.php:59
 msgid "Name is mandatory!"
 msgstr "¡El nombre es obligatorio!"
 
@@ -4178,7 +4178,7 @@ msgstr "Se agregaron nuevos jugadores con licencia:"
 msgid "New name"
 msgstr "Nuevo nombre"
 
-#: user/teamplayers.php:145
+#: user/teamplayers.php:149
 msgid ""
 "New players: enter the jersey number, first name, and last name. Press the "
 "Add button."
@@ -4210,7 +4210,7 @@ msgstr "Próximo"
 msgid "Nickname"
 msgstr "Apodo"
 
-#: user/teamplayers.php:229
+#: user/teamplayers.php:233
 msgid "No"
 msgstr "No"
 
@@ -4291,7 +4291,7 @@ msgstr "Sin goles."
 msgid "No image"
 msgstr "Sin imagen"
 
-#: lib/season.functions.php:1294
+#: lib/season.functions.php:1297
 #, fuzzy
 msgid "No image selected."
 msgstr "Unión seleccionada"
@@ -4853,7 +4853,7 @@ msgstr "Jugadores no acreditados"
 msgid "Players of the game"
 msgstr "Jugadores del juego"
 
-#: user/teamplayers.php:144
+#: user/teamplayers.php:148
 msgid ""
 "Players who already have a profile in Ultiorganizer: enter the full player "
 "name or part of it and press the Search button. Select the correct player "
@@ -5010,11 +5010,11 @@ msgstr "Actitud positiva y autocontrol (de ellos)"
 msgid "Press the button to search for spirit comments"
 msgstr "Presione el botón para buscar comentarios espirituales"
 
-#: cust/default/teamplayers.functions.php:165
+#: cust/default/teamplayers.functions.php:172
 msgid "Prev. Event"
 msgstr "Evento Previo"
 
-#: cust/default/teamplayers.functions.php:160
+#: cust/default/teamplayers.functions.php:167
 msgid "Prev. Team"
 msgstr "Equipo Previo"
 
@@ -5047,7 +5047,7 @@ msgstr "Imprimir todas las hojas de anotación"
 msgid "Print blank scoresheet"
 msgstr "Imprimir hoja de anotación en blanco"
 
-#: user/teamplayers.php:301
+#: user/teamplayers.php:305
 msgid "Print roster"
 msgstr "Imprimir lista de jugadores"
 
@@ -5081,12 +5081,12 @@ msgstr "Política de Privacidad"
 msgid "Private field %s.%s cannot be imported from an event snapshot."
 msgstr ""
 
-#: admin/dbequalize.php:117 user/teamplayers.php:165
+#: admin/dbequalize.php:117 user/teamplayers.php:169
 msgid "Profile"
 msgstr "Perfil"
 
 #: admin/dbequalize.php:367 admin/dbequalize.php:370
-#: cust/default/teamplayers.functions.php:134 user/teamplayers.php:173
+#: cust/default/teamplayers.functions.php:134 user/teamplayers.php:177
 msgid "Profile ID"
 msgstr "ID de perfil"
 
@@ -5435,7 +5435,7 @@ msgstr "Derechos"
 #: scorekeeper/addplayerlists.php:258 scorekeeper/addscoresheet.php:509
 #: scorekeeper/addscoresheet.php:528 scorekeeper/respgames.php:200
 #: user/clubprofile.php:139 user/respteams.php:24 user/teamplayers.php:11
-#: user/teamplayers.php:136 user/teamprofile.php:98
+#: user/teamplayers.php:140 user/teamprofile.php:98
 msgid "Roster"
 msgstr "Lista de Jugadores"
 
@@ -5570,7 +5570,7 @@ msgstr "Sábado"
 #: scorekeeper/result.php:101 spiritkeeper/editgame.php:125
 #: user/addmedialink.php:219 user/addplayerlists.php:453 user/addspirit.php:314
 #: user/clubprofile.php:251 user/playerprofile.php:389 user/respgames.php:230
-#: user/teamplayers.php:279 user/teamprofile.php:191 user/userinfo.php:291
+#: user/teamplayers.php:283 user/teamprofile.php:191 user/userinfo.php:291
 msgid "Save"
 msgstr "Guardar"
 
@@ -5812,7 +5812,7 @@ msgstr "Equipo goleador"
 #: lib/search.functions.php:86 lib/search.functions.php:128
 #: lib/search.functions.php:191 lib/search.functions.php:249
 #: lib/search.functions.php:318 lib/search.functions.php:399
-#: user/teamplayers.php:238 user/teamplayers.php:268
+#: user/teamplayers.php:242 user/teamplayers.php:272
 msgid "Search"
 msgstr "Buscar"
 
@@ -6618,7 +6618,7 @@ msgstr "Tareas"
 msgid "Team"
 msgstr "Equipo"
 
-#: user/clubprofile.php:140 user/teamplayers.php:137 user/teamprofile.php:99
+#: user/clubprofile.php:140 user/teamplayers.php:141 user/teamprofile.php:99
 msgid "Team Profile"
 msgstr "Perfil del equipo"
 
@@ -7168,7 +7168,7 @@ msgstr "Tot."
 #: teamcard.php:320 teamcard.php:364 teamcard.php:586 teamcard.php:777
 #: admin/spirit.php:47 admin/spirit.php:106 admin/spirit.php:155
 #: admin/spirit.php:238 admin/spirit.php:282 admin/spirit.php:342
-#: cust/slkl/mass-accreditation.php:86 lib/common.functions.php:1728
+#: cust/slkl/mass-accreditation.php:86 lib/common.functions.php:1732
 #: spiritkeeper/submitsotg.php:90
 msgid "Total"
 msgstr "Total"
@@ -7468,7 +7468,7 @@ msgstr ""
 msgid "User"
 msgstr "Usuario"
 
-#: frontpage.php:29 menufunctions.php:732 user_guide.php:7
+#: frontpage.php:34 menufunctions.php:732 user_guide.php:7
 msgid "User Guide"
 msgstr "Guía del usuario"
 
@@ -7735,7 +7735,7 @@ msgstr "Los ganadores continúan en:"
 msgid "Winning points"
 msgstr "Puntos ganadores"
 
-#: lib/common.functions.php:1706
+#: lib/common.functions.php:1710
 msgid "Wins"
 msgstr "Ganados"
 
@@ -7764,7 +7764,7 @@ msgstr "Federación Mundial de Disco Volador"
 msgid "X"
 msgstr "X"
 
-#: admin/timekeepertemplates.php:45 user/teamplayers.php:227
+#: admin/timekeepertemplates.php:45 user/teamplayers.php:231
 msgid "Yes"
 msgstr "Sí"
 
@@ -7922,7 +7922,7 @@ msgstr "división"
 
 #: admin/editstanding.php:73 admin/poolgames.php:289 admin/poolgames.php:330
 #: admin/poolgames.php:354 plugins/lisence_modifier.php:240
-#: user/teamplayers.php:210
+#: user/teamplayers.php:214
 msgid "edit"
 msgstr "editar"
 
@@ -8305,7 +8305,7 @@ msgstr "Club desconocido"
 msgid "update"
 msgstr "actualizar"
 
-#: user/teamplayers.php:211
+#: user/teamplayers.php:215
 msgid "view"
 msgstr "vista"
 

--- a/locale/fi_FI.utf8/LC_MESSAGES/messages.po
+++ b/locale/fi_FI.utf8/LC_MESSAGES/messages.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 10:13+0300\n"
+"POT-Creation-Date: 2026-09-10 23:02+0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: stm <stm2@sourceforge.net>\n"
 "Language-Team: Ultiorganizer\n"
@@ -26,8 +26,8 @@ msgid " (enter '0' if not live)"
 msgstr " (syötä '0', jos ei ole live)"
 
 #: cust/default/pdfscoresheet.php:180 cust/default/pdfscoresheet.php:190
-#: cust/default/teamplayers.functions.php:139 cust/slkl/pdfscoresheet.php:145
-#: cust/slkl/pdfscoresheet.php:155 user/teamplayers.php:162
+#: cust/default/teamplayers.functions.php:146 cust/slkl/pdfscoresheet.php:145
+#: cust/slkl/pdfscoresheet.php:155 user/teamplayers.php:166
 msgid "#"
 msgstr "#"
 
@@ -248,7 +248,7 @@ msgstr "Akkreditointi loki"
 msgid "Accreditation official"
 msgstr "Akkreditointi vastaava"
 
-#: user/teamplayers.php:166
+#: user/teamplayers.php:170
 msgid "Accredited"
 msgstr "Akkreditoitu"
 
@@ -283,7 +283,7 @@ msgstr "Aktiivinen"
 #: admin/seasons.php:157 admin/seasonseries.php:173 admin/seasonteams.php:263
 #: admin/serieformats.php:52 admin/timekeepertemplates.php:61
 #: admin/translations.php:522 user/addextraemail.php:95 user/enrollteam.php:140
-#: user/teamplayers.php:269 user/userinfo.php:378 user/userinfo.php:516
+#: user/teamplayers.php:273 user/userinfo.php:378 user/userinfo.php:516
 msgid "Add"
 msgstr "Lisää"
 
@@ -347,7 +347,7 @@ msgstr "Lisää uusi käyttäjä"
 msgid "Add pause"
 msgstr "Lisää tauko"
 
-#: user/teamplayers.php:142
+#: user/teamplayers.php:146
 msgid "Add players to team's roster:"
 msgstr "Lisää pelaajia joukkueeseen:"
 
@@ -693,7 +693,7 @@ msgstr "Maalin syöttäjä ei ole pelaajalistalla"
 #: gamecard.php:241 gamecard.php:247 gameplay.php:136 gameplay.php:157
 #: playerlist.php:36 poolstatus.php:161 poolstatus.php:187 seriesstatus.php:309
 #: teamcard.php:124 teamcard.php:169 ext/poolscoreboard.php:41
-#: ext/teamscoreboard.php:56 lib/common.functions.php:1721
+#: ext/teamscoreboard.php:56 lib/common.functions.php:1725
 msgid "Assists"
 msgstr "Syötöt"
 
@@ -721,7 +721,7 @@ msgstr "Automaattinen akkreditointi"
 msgid "Automatic final standings, not confirmed"
 msgstr "Automaattiset lopulliset sijoitukset, ei vahvistettu"
 
-#: teamcard.php:279 lib/common.functions.php:1732
+#: teamcard.php:279 lib/common.functions.php:1736
 msgid "Average"
 msgstr "Keskiarvo"
 
@@ -788,7 +788,7 @@ msgstr "Takaisin:"
 msgid "Back to Spirit tools"
 msgstr "Takaisin spirit-työkaluihin"
 
-#: user/teamplayers.php:291
+#: user/teamplayers.php:295
 msgid "Back to entering player numbers"
 msgstr "Takaisin syöttämään pelaajanumeroita"
 
@@ -925,7 +925,7 @@ msgid "Call or discussion"
 msgstr "Rikehuuto tai keskustelu"
 
 #: cust/default/pdfscoresheet.php:638 cust/gummis/pdfscoresheet.php:698
-#: cust/wfdf/pdfscoresheet.php:1273 lib/common.functions.php:1724
+#: cust/wfdf/pdfscoresheet.php:1273 lib/common.functions.php:1728
 #: user/adddefensesheet.php:358
 msgid "Callahan"
 msgstr "Callahan"
@@ -956,7 +956,7 @@ msgstr "Callahan-maali"
 #: scorekeeper/result.php:88 user/adddefensesheet.php:317
 #: user/addscoresheet.php:708 user/select_poolselector.php:26
 #: user/select_poolselector.php:29 user/select_poolselector.php:32
-#: user/select_poolselector.php:35 user/teamplayers.php:280
+#: user/select_poolselector.php:35 user/teamplayers.php:284
 #: user/userinfo.php:292
 msgid "Cancel"
 msgstr "Peruuta"
@@ -1178,7 +1178,7 @@ msgstr "Seura"
 msgid "Club Card"
 msgstr "Seuraprofiili"
 
-#: user/clubprofile.php:141 user/teamplayers.php:138 user/teamprofile.php:100
+#: user/clubprofile.php:141 user/teamplayers.php:142 user/teamprofile.php:100
 msgid "Club Profile"
 msgstr "Seuraprofiili"
 
@@ -1393,11 +1393,11 @@ msgstr "Muunna InnoDB/utf8mb4-muotoon nyt"
 msgid "Coordinates"
 msgstr "Koordinaatit"
 
-#: admin/seasonteams.php:288 user/teamplayers.php:195
+#: admin/seasonteams.php:288 user/teamplayers.php:199
 msgid "Copy"
 msgstr "Kopioi"
 
-#: user/teamplayers.php:186
+#: user/teamplayers.php:190
 msgid "Copy team roster from:"
 msgstr "Kopioi pelaajalista:"
 
@@ -1571,7 +1571,7 @@ msgstr "Tietokannan versio"
 msgid "Date"
 msgstr "Pvm"
 
-#: playercard.php:97 cust/default/teamplayers.functions.php:154
+#: playercard.php:97 cust/default/teamplayers.functions.php:161
 #: user/playerprofile.php:271
 msgid "Date of birth"
 msgstr "Syntymäaika"
@@ -1628,7 +1628,7 @@ msgstr "Puolustuspöytäkirja tallennettu"
 
 #: defensestatus.php:80 defensestatus.php:82 gameplay.php:679 gameplay.php:702
 #: teamcard.php:127 teamcard.php:430 teamcard.php:521
-#: cust/wfdf/pdfscoresheet.php:252 lib/common.functions.php:1726
+#: cust/wfdf/pdfscoresheet.php:252 lib/common.functions.php:1730
 msgid "Defences"
 msgstr "Puolustukset"
 
@@ -1639,7 +1639,7 @@ msgstr "Puolustuspisteet"
 #: admin/poolmoves.php:233 admin/poolmoves.php:305 admin/seasonpoints.php:204
 #: admin/spirit.php:403 admin/translations.php:550 admin/users.php:93
 #: admin/users.php:95 mobile/deletescore.php:23 mobile/deletescore.php:47
-#: scorekeeper/deletescore.php:44 user/teamplayers.php:175
+#: scorekeeper/deletescore.php:44 user/teamplayers.php:179
 msgid "Delete"
 msgstr "Poista"
 
@@ -1893,7 +1893,7 @@ msgstr "Lataa pelaajan tietosuojaraportti"
 msgid "Download registered user privacy report"
 msgstr "Lataa rekisteröidyn käyttäjän tietosuojaraportti"
 
-#: lib/common.functions.php:1708
+#: lib/common.functions.php:1712
 msgid "Draws"
 msgstr "Tasapelit"
 
@@ -2404,12 +2404,12 @@ msgid "Fields"
 msgstr "Kentät"
 
 #: lib/club.functions.php:211 lib/player.functions.php:1109
-#: lib/season.functions.php:1303 lib/team.functions.php:1416
+#: lib/season.functions.php:1306 lib/team.functions.php:1419
 msgid "File is not supported image format"
 msgstr "Tiedosto ei ole tuettu kuvaformaatti"
 
 #: lib/club.functions.php:203 lib/player.functions.php:1101
-#: lib/season.functions.php:1298 lib/team.functions.php:1408
+#: lib/season.functions.php:1301 lib/team.functions.php:1411
 msgid "File is too large"
 msgstr "Tiedosto on liian suuri"
 
@@ -2511,8 +2511,8 @@ msgstr "Etunimi"
 msgid "First Offence"
 msgstr "Ensimmäinen hyökkäys"
 
-#: cust/default/teamplayers.functions.php:144 user/playerprofile.php:222
-#: user/teamplayers.php:163
+#: cust/default/teamplayers.functions.php:151 user/playerprofile.php:222
+#: user/teamplayers.php:167
 msgid "First name"
 msgstr "Etunimi"
 
@@ -2545,7 +2545,7 @@ msgstr "Seuraa sähköpostissa olevia ohjeita vahvistaaksesi rekisteröitymisen"
 msgid "Follow the link in the email to confirm your registration."
 msgstr "Seuraa sähköpostissa olevaa linkkiä vahvistaaksesi rekisteröitymisen."
 
-#: frontpage.php:35
+#: frontpage.php:40
 msgid "For feedback, improvement ideas, or any other questions, contact:"
 msgstr ""
 "Jos haluat antaa palautetta, kehitysehdotuksia tai kysyä mitä tahansa, ota "
@@ -2889,7 +2889,7 @@ msgstr "Yhteenveto pelin kulusta"
 #: admin/seasonstandings.php:313 admin/seasonstandings.php:370
 #: admin/seasonstats.php:21 admin/seasonstats.php:35 admin/seriesgames.php:31
 #: admin/seriesgames.php:41 admin/stats.php:120 ext/poolscoreboard.php:40
-#: ext/teamscoreboard.php:55 lib/common.functions.php:1704
+#: ext/teamscoreboard.php:55 lib/common.functions.php:1708
 #: lib/search.functions.php:786
 msgid "Games"
 msgstr "Pelit"
@@ -2997,11 +2997,11 @@ msgstr "Maalin aika"
 #: gameplay.php:540 playerlist.php:37 poolstatus.php:161 poolstatus.php:187
 #: poolstatus.php:302 seriesstatus.php:309 teamcard.php:125 teamcard.php:170
 #: ext/poolscoreboard.php:42 ext/teamscoreboard.php:57
-#: lib/common.functions.php:1719
+#: lib/common.functions.php:1723
 msgid "Goals"
 msgstr "Maalit"
 
-#: lib/common.functions.php:1714
+#: lib/common.functions.php:1718
 msgid "Goals against"
 msgstr "Päästetyt maalit"
 
@@ -3009,11 +3009,11 @@ msgstr "Päästetyt maalit"
 msgid "Goals against avg."
 msgstr "Päästettyjen maalien ka."
 
-#: lib/common.functions.php:1716
+#: lib/common.functions.php:1720
 msgid "Goals diff"
 msgstr "Maaliero"
 
-#: lib/common.functions.php:1712
+#: lib/common.functions.php:1716
 msgid "Goals for"
 msgstr "Tehdyt maalit"
 
@@ -3312,8 +3312,8 @@ msgid ""
 msgstr ""
 
 #: lib/club.functions.php:234 lib/player.functions.php:1132
-#: lib/season.functions.php:1331 lib/season.functions.php:1335
-#: lib/team.functions.php:1440
+#: lib/season.functions.php:1334 lib/season.functions.php:1338
+#: lib/team.functions.php:1443
 msgid "Image upload failed because the server could not process the image."
 msgstr ""
 "Kuvan lataaminen epäonnistui, koska palvelin ei pystynyt käsittelemään kuvaa."
@@ -3485,7 +3485,7 @@ msgstr "Virheellinen peli."
 msgid "Invalid link target."
 msgstr "Virheellinen linkkikohde."
 
-#: install.php:718
+#: install.php:739
 msgid "Invalid password (min. 5, max. 20 characters)."
 msgstr "Virheellinen salasana (vähintään 5 ja enintään 20 merkkiä)."
 
@@ -3608,8 +3608,8 @@ msgstr "Sukunimi"
 msgid "Last login"
 msgstr "Viimeinen kirjautuminen"
 
-#: cust/default/teamplayers.functions.php:149 user/playerprofile.php:226
-#: user/teamplayers.php:164
+#: cust/default/teamplayers.functions.php:156 user/playerprofile.php:226
+#: user/teamplayers.php:168
 msgid "Last name"
 msgstr "Sukunimi"
 
@@ -3649,7 +3649,7 @@ msgstr ""
 "kommentin, kun molemmat joukkueet ovat lähettäneet arvionsa, tekemättä "
 "kommenteista julkisia."
 
-#: user/playerprofile.php:197 user/teamplayers.php:170
+#: user/playerprofile.php:197 user/teamplayers.php:174
 msgid "License"
 msgstr "Lisenssi"
 
@@ -3785,7 +3785,7 @@ msgstr "Pituusaste"
 msgid "Losers continue in:"
 msgstr "Häviäjä jatkaa:"
 
-#: lib/common.functions.php:1710
+#: lib/common.functions.php:1714
 msgid "Losses"
 msgstr "Tappiot"
 
@@ -3858,12 +3858,12 @@ msgstr "Joukkosyöttäminen"
 msgid "Media owner"
 msgstr "Median omistaja"
 
-#: user/teamplayers.php:168
+#: cust/default/teamplayers.functions.php:140 user/teamplayers.php:172
 msgid "Member ID"
 msgstr "Jäsen nro."
 
 #: admin/accreditation.php:259 admin/accreditation.php:261
-#: user/playerprofile.php:207 user/teamplayers.php:169
+#: user/playerprofile.php:207 user/teamplayers.php:173
 msgid "Membership"
 msgstr "Jäsenmaksu"
 
@@ -3908,7 +3908,7 @@ msgid "Missing and duplicate shirt numbers"
 msgstr "Puuttuvat ja päällekkäiset pelinumerot"
 
 #: lib/club.functions.php:215 lib/player.functions.php:1113
-#: lib/season.functions.php:1307 lib/team.functions.php:1420
+#: lib/season.functions.php:1310 lib/team.functions.php:1423
 msgid "Missing image processing support on the server."
 msgstr "Palvelimelta puuttuu kuvankäsittelyn tuki."
 
@@ -4084,7 +4084,7 @@ msgstr "Nimi ei voi olla tyhjä"
 msgid "Name in Schedule"
 msgstr "Nimi aikataulussa"
 
-#: admin/addseasonteams.php:40
+#: admin/addseasonteams.php:40 user/teamplayers.php:59
 msgid "Name is mandatory!"
 msgstr "Nimi on pakollinen!"
 
@@ -4136,7 +4136,7 @@ msgstr "Uusia lisenssipelaajia lisätty:"
 msgid "New name"
 msgstr "Uusi nimi"
 
-#: user/teamplayers.php:145
+#: user/teamplayers.php:149
 msgid ""
 "New players: enter the jersey number, first name, and last name. Press the "
 "Add button."
@@ -4168,7 +4168,7 @@ msgstr "Seuraava"
 msgid "Nickname"
 msgstr "Lempinimi"
 
-#: user/teamplayers.php:229
+#: user/teamplayers.php:233
 msgid "No"
 msgstr "Ei"
 
@@ -4249,7 +4249,7 @@ msgstr "Ei maaleja."
 msgid "No image"
 msgstr "Ei Kuvaa"
 
-#: lib/season.functions.php:1294
+#: lib/season.functions.php:1297
 #, fuzzy
 msgid "No image selected."
 msgstr "Yhdistä valitut"
@@ -4803,7 +4803,7 @@ msgstr "Akkreditoimattomat pelaajat"
 msgid "Players of the game"
 msgstr "Pelin pelaajat"
 
-#: user/teamplayers.php:144
+#: user/teamplayers.php:148
 msgid ""
 "Players who already have a profile in Ultiorganizer: enter the full player "
 "name or part of it and press the Search button. Select the correct player "
@@ -4960,11 +4960,11 @@ msgstr "Positiivinen asenne ja itsehillintä (heidän)"
 msgid "Press the button to search for spirit comments"
 msgstr "Paina painiketta hakeaksesi spirit-kommentteja"
 
-#: cust/default/teamplayers.functions.php:165
+#: cust/default/teamplayers.functions.php:172
 msgid "Prev. Event"
 msgstr "Edel. Tapahtuma"
 
-#: cust/default/teamplayers.functions.php:160
+#: cust/default/teamplayers.functions.php:167
 msgid "Prev. Team"
 msgstr "Edel. Joukkue"
 
@@ -4996,7 +4996,7 @@ msgstr "Tulosta kaikki pöytäkirjat"
 msgid "Print blank scoresheet"
 msgstr "Tulosta tyhjä pöytäkirja"
 
-#: user/teamplayers.php:301
+#: user/teamplayers.php:305
 msgid "Print roster"
 msgstr "Tulosta pelaajalista"
 
@@ -5030,12 +5030,12 @@ msgstr "Yksityisyydensuoja"
 msgid "Private field %s.%s cannot be imported from an event snapshot."
 msgstr ""
 
-#: admin/dbequalize.php:117 user/teamplayers.php:165
+#: admin/dbequalize.php:117 user/teamplayers.php:169
 msgid "Profile"
 msgstr "Profiili"
 
 #: admin/dbequalize.php:367 admin/dbequalize.php:370
-#: cust/default/teamplayers.functions.php:134 user/teamplayers.php:173
+#: cust/default/teamplayers.functions.php:134 user/teamplayers.php:177
 msgid "Profile ID"
 msgstr "Profiilin tunnus"
 
@@ -5382,7 +5382,7 @@ msgstr "Oikeudet"
 #: scorekeeper/addplayerlists.php:258 scorekeeper/addscoresheet.php:509
 #: scorekeeper/addscoresheet.php:528 scorekeeper/respgames.php:200
 #: user/clubprofile.php:139 user/respteams.php:24 user/teamplayers.php:11
-#: user/teamplayers.php:136 user/teamprofile.php:98
+#: user/teamplayers.php:140 user/teamprofile.php:98
 msgid "Roster"
 msgstr "Pelaajalista"
 
@@ -5517,7 +5517,7 @@ msgstr "Lauantai"
 #: scorekeeper/result.php:101 spiritkeeper/editgame.php:125
 #: user/addmedialink.php:219 user/addplayerlists.php:453 user/addspirit.php:314
 #: user/clubprofile.php:251 user/playerprofile.php:389 user/respgames.php:230
-#: user/teamplayers.php:279 user/teamprofile.php:191 user/userinfo.php:291
+#: user/teamplayers.php:283 user/teamprofile.php:191 user/userinfo.php:291
 msgid "Save"
 msgstr "Tallenna"
 
@@ -5759,7 +5759,7 @@ msgstr "Joukkue"
 #: lib/search.functions.php:86 lib/search.functions.php:128
 #: lib/search.functions.php:191 lib/search.functions.php:249
 #: lib/search.functions.php:318 lib/search.functions.php:399
-#: user/teamplayers.php:238 user/teamplayers.php:268
+#: user/teamplayers.php:242 user/teamplayers.php:272
 msgid "Search"
 msgstr "Hae"
 
@@ -6560,7 +6560,7 @@ msgstr "Tehtävä"
 msgid "Team"
 msgstr "Joukkue"
 
-#: user/clubprofile.php:140 user/teamplayers.php:137 user/teamprofile.php:99
+#: user/clubprofile.php:140 user/teamplayers.php:141 user/teamprofile.php:99
 msgid "Team Profile"
 msgstr "Joukkueprofiili"
 
@@ -7093,7 +7093,7 @@ msgstr "Yht."
 #: teamcard.php:320 teamcard.php:364 teamcard.php:586 teamcard.php:777
 #: admin/spirit.php:47 admin/spirit.php:106 admin/spirit.php:155
 #: admin/spirit.php:238 admin/spirit.php:282 admin/spirit.php:342
-#: cust/slkl/mass-accreditation.php:86 lib/common.functions.php:1728
+#: cust/slkl/mass-accreditation.php:86 lib/common.functions.php:1732
 #: spiritkeeper/submitsotg.php:90
 msgid "Total"
 msgstr "Yhteensä"
@@ -7390,7 +7390,7 @@ msgstr ""
 msgid "User"
 msgstr "Käyttäjä"
 
-#: frontpage.php:29 menufunctions.php:732 user_guide.php:7
+#: frontpage.php:34 menufunctions.php:732 user_guide.php:7
 msgid "User Guide"
 msgstr "Käyttöopas"
 
@@ -7650,7 +7650,7 @@ msgstr "Voittaja jatkaa:"
 msgid "Winning points"
 msgstr "Voittopiste"
 
-#: lib/common.functions.php:1706
+#: lib/common.functions.php:1710
 msgid "Wins"
 msgstr "Voitot"
 
@@ -7679,7 +7679,7 @@ msgstr "Maailman Liitokiekkoliitto"
 msgid "X"
 msgstr "X"
 
-#: admin/timekeepertemplates.php:45 user/teamplayers.php:227
+#: admin/timekeepertemplates.php:45 user/teamplayers.php:231
 msgid "Yes"
 msgstr "Kyllä"
 
@@ -7834,7 +7834,7 @@ msgstr "sarja"
 
 #: admin/editstanding.php:73 admin/poolgames.php:289 admin/poolgames.php:330
 #: admin/poolgames.php:354 plugins/lisence_modifier.php:240
-#: user/teamplayers.php:210
+#: user/teamplayers.php:214
 msgid "edit"
 msgstr "muokkaa"
 
@@ -8217,7 +8217,7 @@ msgstr "Tuntematon seura"
 msgid "update"
 msgstr "päivitä"
 
-#: user/teamplayers.php:211
+#: user/teamplayers.php:215
 msgid "view"
 msgstr "katso"
 

--- a/user/teamplayers.php
+++ b/user/teamplayers.php
@@ -45,7 +45,7 @@ if (!empty($_POST['remove_x'])) {
             $num = intval($_POST["number0"]);
         }
 
-        AddPlayer($teamId, trim($_POST["firstname0"]), trim($_POST["lastname0"]), $_POST["profileId0"], $num);
+        $playerid = AddPlayer($teamId, trim($_POST["firstname0"]), trim($_POST["lastname0"]), $_POST["profileId0"], $num);
         //add new player when accreditation id is NOT known
     } else {
         if (isset($_POST["number0"])) {
@@ -55,7 +55,11 @@ if (!empty($_POST['remove_x'])) {
         }
         $playerid = AddPlayer($teamId, trim($_POST["firstname0"]), trim($_POST["lastname0"]), 0, $num);
     }
-    header("location:?view=user/teamplayers&team=$teamId");
+    if (empty($playerid)) {
+        echo "<p class='warning'>" . _("Name is mandatory!") . "</p>";
+    } else {
+        header("location:?view=user/teamplayers&team=$teamId");
+    }
 } elseif (!empty($_POST['save'])) {
     for ($i = 0; $i < count($_POST['playerEdited']); $i++) {
         if ($_POST['playerEdited'][$i] == "yes") {

--- a/user/teamplayers.php
+++ b/user/teamplayers.php
@@ -33,26 +33,18 @@ if (!empty($_POST['remove_x'])) {
         RemovePlayer($id);
     }
 } elseif (!empty($_POST['add'])) {
+    // An empty field means no jersey number. 0 is a number of its own, so it
+    // must not collapse to either the empty case or vice versa.
+    $num = isset($_POST["number0"]) && trim($_POST["number0"]) !== '' ? intval($_POST["number0"]) : -1;
     //add new player when accreditation id is known
     if (
         isset($_POST["firstname0"]) && isset($_POST["lastname0"])
         && (strlen($_POST["firstname0"]) > 0 || strlen($_POST["lastname0"]) > 0)
         && !empty($_POST["profileId0"])
     ) {
-
-        $num = -1;
-        if (isset($_POST["number0"]) && intval($_POST["number0"]) > 0) {
-            $num = intval($_POST["number0"]);
-        }
-
         $playerid = AddPlayer($teamId, trim($_POST["firstname0"]), trim($_POST["lastname0"]), $_POST["profileId0"], $num);
         //add new player when accreditation id is NOT known
     } else {
-        if (isset($_POST["number0"])) {
-            $num = intval($_POST["number0"]);
-        } else {
-            $num = -1;
-        }
         $playerid = AddPlayer($teamId, trim($_POST["firstname0"]), trim($_POST["lastname0"]), 0, $num);
     }
     if (empty($playerid)) {
@@ -102,7 +94,7 @@ if (!empty($_POST['remove_x'])) {
         }
     }
     if (!empty($_POST['profileId0'])) {
-        $num = isset($_POST['number0']) && $_POST['number0'] !== '' ? intval($_POST['number0']) : -1;
+        $num = isset($_POST['number0']) && trim($_POST['number0']) !== '' ? intval($_POST['number0']) : -1;
         AddPlayer(
             $teamId,
             trim($_POST['firstname0'] ?? ''),

--- a/user/teamplayers.php
+++ b/user/teamplayers.php
@@ -61,7 +61,7 @@ if (!empty($_POST['remove_x'])) {
         header("location:?view=user/teamplayers&team=$teamId");
     }
 } elseif (!empty($_POST['save'])) {
-    for ($i = 0; $i < count($_POST['playerEdited']); $i++) {
+    for ($i = 0; $i < count($_POST['playerEdited'] ?? []); $i++) {
         if ($_POST['playerEdited'][$i] == "yes") {
             $id = $_POST['playerId'][$i];
             $playerInfo = PlayerInfo($_POST['playerId'][$i]);
@@ -100,6 +100,16 @@ if (!empty($_POST['remove_x'])) {
                 }
             }
         }
+    }
+    if (!empty($_POST['profileId0'])) {
+        $num = isset($_POST['number0']) && $_POST['number0'] !== '' ? intval($_POST['number0']) : -1;
+        AddPlayer(
+            $teamId,
+            trim($_POST['firstname0'] ?? ''),
+            trim($_POST['lastname0'] ?? ''),
+            $_POST['profileId0'],
+            $num,
+        );
     }
     header("location:?view=user/teamplayers&team=$teamId");
 } elseif (!empty($_POST['copy'])) {


### PR DESCRIPTION
Six fixes around the team roster page and the accreditation admin view. The
motivation is the **slkl** installation — it is the one that uses membership
Ids, licenses and the Accreditation page — but only two of the six changes are
actually gated on `CUSTOMIZATIONS == "slkl"`. The rest are general fixes that
every installation gets, including a PHP 8 fatal. See the split at the bottom.

## Roster page (`user/teamplayers.php`, `lib/team.functions.php`)

**Blank player rows could be created.** Pressing *Add* with both name fields
empty inserted a blank `uo_player_profile` row and a blank `uo_player` row: the
page only checked the name on the branch where the search dialog had returned a
profile id. The guard now lives inside `AddPlayer()` instead of in the page, so
`plugins/import_csv_players.php` and `plugins/import_xml_ffindr.php` cannot
bypass it either. It rejects only when *both* names are blank, matching the "at
least one name" rule the page already applied. `AddPlayer()` returns the new
player id, so returning `0` reads as failure and the page reports it with the
existing `Name is mandatory!` msgid instead of redirecting.

**Save did nothing for the new player row, and fataled on an empty roster.**
Selecting a profile from the search dialog for the bottom "new player" row only
armed *Add* (relabelled *Confirm*). Pressing *Save* silently dropped the
selection, because the save branch only loops over the existing roster. Save
also crashed on a team with no players: the `playerEdited` hidden fields are
emitted inside the per-player loop while the Save button is rendered above it,
so an empty roster posts no `playerEdited` at all and `count(null)` is a
`TypeError` on PHP 8. Reproduced as an HTTP 200 carrying
`TypeError ... must be of type Countable|array, null given` at
`teamplayers.php:64`; now a 302. The two faults compound — arming Save for the
new player row is exactly what leads someone to press Save on a still-empty
roster, i.e. the first-player case. Save is now armed alongside Confirm, the
pending player is added when the save carries a `profileId0`, and the missing
`playerEdited` array defaults to `[]`.

**Jersey number `0`.** The two add branches got it wrong in opposite
directions: with a profile selected the guard was `intval() > 0`, so a typed `0`
was discarded; without a profile it was a bare `intval()`, so an empty field
became `0`. Verified against the running app before the change (`'0'` -> `-1` on
one branch, `''` -> `0` on the other). Both branches now share one expression,
matching what `NormalizedPlayerNumberSql()` already does on the save path: an
empty field means no number, `0` means the number 0. Checked end to end on a
scratch team, whose rows were removed afterwards. The search path needed no
change — its guard reads the field as a string and `"0"` is truthy in JS.

## Member ID column in the search dialog (`cust/default/teamplayers.functions.php`, slkl only)

On the slkl roster the *Member ID* column holds `uo_player.accreditation_id`,
and its *Search* link opens the profile search dialog. That dialog listed
Profile ID, jersey, names, birthdate and previous team/event, but never the
accreditation id it exists to fill. A name can have several profiles with only
one of them linked to a license, so the entries were indistinguishable;
selecting the unlicensed one left the Member ID cell empty and Save wrote
`accreditation_id=0`, which brought the *Search* link straight back with nothing
to explain why. `AccreditationId` was already in the datasource response and the
response schema, so this only displays what was already fetched.

## Accreditation accId view: N+1 removal (`admin/accreditation.php`, `lib/`)

The accId view looped over `SeasonAllPlayers()` twice, calling `PlayerInfo()`
for every player of the season plus `PlayerSeasonTeamPlayedGames()` and
`LicenseData()` for every player it kept — 1451 statements for one page on a
649-player season. Added grouped counterparts in `lib/` following the existing
`SeasonPlayerStatRows()` pattern (`SeasonPlayerInfos()`,
`SeasonPlayerTeamPlayedGames()`, `LicenseDataList()`), read the player rows
once, and merge games and licenses in PHP.

Output is unchanged. `SeasonAllPlayers()` uses `LEFT JOIN` but filters on
`ser.season`, which makes the joins effectively inner, and the new query keeps
the same `ORDER BY ser.name, t.name, p.lastname, p.firstname`. Compared
empirically on the local dev database, season `2023.2`: old shape 649 rows /
649 distinct `player_id`, new shape 649 rows / 649 distinct `player_id` — so
keying the result by player loses nothing.

## Gettext catalogs

`docs/ai/fix-user-language/scripts/update-gettext-catalogs.sh` was re-run. Only
`#:` source-location comments and the `POT-Creation-Date` header move — no
msgid, msgstr or fuzzy flag changes, so the compiled `.mo` files stay valid and
need no rebuild. Both strings this branch uses on new lines (`Member ID`,
`Name is mandatory!`) already existed and are already translated in every
catalog. The refresh also corrects reference drift that predates this branch in
`admin/`, `lib/common.functions.php` and `lib/season.functions.php`.

## What is slkl-specific and what is not

slkl-gated (explicit `CUSTOMIZATIONS == "slkl"` guards):

- the Member ID / `AccreditationId` column in the search dialog
- the `LicenseDataList()` merge and the `external` sort in the accId view

Note that the dialog file lives under `cust/default/` but the new column sits
inside an slkl guard, so default and wfdf rendering is unchanged.

Every installation:

- the `AddPlayer()` blank-name guard, including the two importer plugins
- jersey `0` handling on both add branches
- Save arming for the new player row and the empty-roster `TypeError` fix
- the accId per-player `PlayerInfo()` / games N+1 removal (only the license half
  of that view is slkl)
- the gettext reference refresh

## Verification

- `composer check` (PHP-CS-Fixer + PHPStan) and `eslint script` clean.
- Roster add/save flows exercised against the running dev app as described
  above; scratch rows removed.
- accId row counts compared old vs new on the dev database (numbers above).
- CI runs the repo checkers and the full `ultiorganizer-tests` harness matrix on
  this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHb42Qn3yyXhb4pxmKjBqa
