### PR TITLE
Keep sidebar menus stable while page content loads

### DIFF
--- a/cust/default/ultiorganizer.css
+++ b/cust/default/ultiorganizer.css
@@ -320,6 +320,11 @@ table[border="2"] {
 	margin: 0;
 }
 
+/* Reserve both columns before streamed HTML reaches the content cell. */
+.menu_column {
+	width: 200px;
+}
+
 .page_bottom {
 	width: 100%;
 }
@@ -419,6 +424,14 @@ table[border="2"] {
 	.page_middle > table {
 		width: 100%;
 		margin: 0;
+	}
+
+	.menu_column {
+		display: none;
+	}
+
+	.tdcontent {
+		width: 100%;
 	}
 
 	.gameplay-scoreboards {
@@ -521,7 +534,6 @@ table[border="2"] {
 }
 
 .leftmenulinks {
-	float: left;
 	text-align: left;
 	vertical-align: top;
 	background-color: var(--surface-muted);
@@ -536,7 +548,6 @@ table[border="2"] {
 }
 
 .leftmenulinks_plain {
-	float: left;
 	text-align: left;
 	vertical-align: top;
 	background-color: transparent;
@@ -563,7 +574,6 @@ table[border="2"] {
 
 .tdcontent {
 	/*border-left: solid #598788 4px;*/
-	width: 100%;
 	/* Scroll over-wide tables within the content cell (see .page_middle > table). */
 	overflow-x: auto;
 }

--- a/menufunctions.php
+++ b/menufunctions.php
@@ -440,7 +440,7 @@ function seasonSelection()
     }
 }
 
-function pageMainStart($printable = false)
+function pageMainStart($printable = false, $withMenu = false)
 {
     if ($printable) {
         echo "<table style='width:100%;'><tr>";
@@ -448,7 +448,10 @@ function pageMainStart($printable = false)
     }
 
     echo "<table style='border:1px solid #fff;background-color: #ffffff;'>\n";
-    echo "<colgroup><col class='menu_column'/><col/></colgroup><tr>\n";
+    if ($withMenu) {
+        echo "<colgroup><col class='menu_column'/><col/></colgroup>\n";
+    }
+    echo "<tr>\n";
 }
 /**
  * Creates menus on left side of page.
@@ -460,7 +463,7 @@ function leftMenu($id = 0, $pagestart = true, $printable = false)
 {
 
     if ($pagestart) {
-        pageMainStart($printable);
+        pageMainStart($printable, true);
     }
     if ($printable) {
         return;

--- a/menufunctions.php
+++ b/menufunctions.php
@@ -447,7 +447,8 @@ function pageMainStart($printable = false)
         return;
     }
 
-    echo "<table style='border:1px solid #fff;background-color: #ffffff;'><tr>\n";
+    echo "<table style='border:1px solid #fff;background-color: #ffffff;'>\n";
+    echo "<colgroup><col class='menu_column'/><col/></colgroup><tr>\n";
 }
 /**
  * Creates menus on left side of page.


### PR DESCRIPTION
Slow page responses can display sidebar sections side by side until the content cell arrives, then snap them back into a vertical menu. Declare both layout columns before rendering the sidebar, reserve a 200 px menu column, and remove floats from the menu sections.

Only declare sidebar columns when rendering a menu. Pages without a sidebar, including the scheduling editor, and printable views keep their single-column layout. On mobile, hide the sidebar column and retain full content width while the navigation drawer is open.

Validation:
- Delayed-content Chromium checks and screenshots at 1400 px and 400 px, using the local accreditation page and the default, SLKL, and WFDF stylesheets. The desktop sidebar stays 200 px wide before and after content arrives; opening the mobile drawer leaves content width unchanged.
- Printable schedule screenshot and measurement: no sidebar column, full 920 px content width.
- Scheduling editor screenshots at desktop and mobile widths: its desktop content uses the full 919 px instead of the reserved 200 px sidebar column.
- PHP formatting, PHPStan, and Stylelint passed.
- Full test matrix passed all eight configurations and 27 JavaScript checks.
- Release package built successfully; both updated runtime files are included.
